### PR TITLE
k3s-io/k3s: bump version to v1.30.9+k3s1

### DIFF
--- a/.charts/1-infrastructure/system-upgrade-controller/values.yaml
+++ b/.charts/1-infrastructure/system-upgrade-controller/values.yaml
@@ -1,2 +1,2 @@
 kubernetes:
-  version: v1.31.4+k3s1
+  version: v1.30.9+k3s1

--- a/1-infrastructure/system-upgrade-controller/plans.yaml
+++ b/1-infrastructure/system-upgrade-controller/plans.yaml
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.31.4+k3s1
+  version: v1.30.9+k3s1
 ---
 # Source: system-upgrade-controller/templates/plans.yaml
 # Agent plan
@@ -42,4 +42,4 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.31.4+k3s1
+  version: v1.30.9+k3s1


### PR DESCRIPTION



<Actions>
    <action id="32378aa2665b229d8619fccc2da26de763ac7ea67bcad573ba096abdf76f9240">
        <h3>k3s-io/k3s</h3>
        <details id="37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f">
            <summary>k3s-io/k3s: bump version to v1.30.9+k3s1</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.kubernetes.version&#34; updated from &#34;v1.31.4+k3s1&#34; to &#34;v1.30.9+k3s1&#34;, in file &#34;.charts/1-infrastructure/system-upgrade-controller/values.yaml&#34;</p>
            <details>
                <summary>v1.30.9+k3s1</summary>
                <pre>&#xA;Release published on the 2025-01-28 16:21:46 +0000 UTC at the url https://github.com/k3s-io/k3s/releases/tag/v1.30.9%2Bk3s1&#xA;&#xA;&lt;!-- v1.30.9+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.30.9, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#changelog-since-v1308).&#xD;&#xA;&#xD;&#xA;## Changes since v1.30.8+k3s1:&#xD;&#xA;&#xD;&#xA;* Add guardrail for etcd-snapshot [(#11394)](https://github.com/k3s-io/k3s/pull/11394)&#xD;&#xA;* Backports for 2025-01 [(#11567)](https://github.com/k3s-io/k3s/pull/11567)&#xD;&#xA;* Add auto import images for containerd image store [(#11561)](https://github.com/k3s-io/k3s/pull/11561)&#xD;&#xA;* 2025 January Backports [(#11589)](https://github.com/k3s-io/k3s/pull/11589)&#xD;&#xA;* Load kernel modules for nft in agent setup [(#11597)](https://github.com/k3s-io/k3s/pull/11597)&#xD;&#xA;* Fix local password validation when bind-address is set [(#11612)](https://github.com/k3s-io/k3s/pull/11612)&#xD;&#xA;* Update to v1.30.9-k3s1 and Go 1.22.10 [(#11618)](https://github.com/k3s-io/k3s/pull/11618)&#xD;&#xA;* Remove local restriction for deferred node password validation [(#11650)](https://github.com/k3s-io/k3s/pull/11650)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.30.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#v1309) |&#xD;&#xA;| Kine | [v0.13.5](https://github.com/k3s-io/kine/releases/tag/v0.13.5) |&#xD;&#xA;| SQLite | [3.46.1](https://sqlite.org/releaselog/3_46_1.html) |&#xD;&#xA;| Etcd | [v3.5.16-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.16-k3s1) |&#xD;&#xA;| Containerd | [v1.7.23-k3s2](https://github.com/k3s-io/containerd/releases/tag/v1.7.23-k3s2) |&#xD;&#xA;| Runc | [v1.2.4-k3s1](https://github.com/opencontainers/runc/releases/tag/v1.2.4-k3s1) |&#xD;&#xA;| Flannel | [v0.25.7](https://github.com/flannel-io/flannel/releases/tag/v0.25.7) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v2.11.18](https://github.com/traefik/traefik/releases/tag/v2.11.18) |&#xD;&#xA;| CoreDNS | [v1.12.0](https://github.com/coredns/coredns/releases/tag/v1.12.0) | &#xD;&#xA;| Helm-controller | [v0.16.5](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.5) |&#xD;&#xA;| Local-path-provisioner | [v0.0.30](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.30) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;## What&#39;s Changed&#xD;&#xA;* [release-1.30] Remove local restriction for deferred node password validation by @brandond in https://github.com/k3s-io/k3s/pull/11650&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.30.9-rc1+k3s1...v1.30.9+k3s1</pre>
            </details>
        </details>
        <a href="https://github.com/mprochowski/k3s-cluster-gitops/actions/runs/13045449672">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

