### PR TITLE
k3s-io/k3s: bump version to v1.31.6+k3s1

### DIFF
--- a/.charts/1-infrastructure/system-upgrade-controller/values.yaml
+++ b/.charts/1-infrastructure/system-upgrade-controller/values.yaml
@@ -1,2 +1,2 @@
 kubernetes:
-  version: v1.31.5+k3s1
+  version: v1.31.6+k3s1

--- a/1-infrastructure/system-upgrade-controller/plans.yaml
+++ b/1-infrastructure/system-upgrade-controller/plans.yaml
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.31.5+k3s1
+  version: v1.31.6+k3s1
 ---
 # Source: system-upgrade-controller/templates/plans.yaml
 # Agent plan
@@ -42,4 +42,4 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.31.5+k3s1
+  version: v1.31.6+k3s1


### PR DESCRIPTION



<Actions>
    <action id="32378aa2665b229d8619fccc2da26de763ac7ea67bcad573ba096abdf76f9240">
        <h3>k3s-io/k3s</h3>
        <details id="37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f">
            <summary>k3s-io/k3s: bump version to v1.31.6+k3s1</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.kubernetes.version&#34; updated from &#34;v1.31.5+k3s1&#34; to &#34;v1.31.6+k3s1&#34;, in file &#34;.charts/1-infrastructure/system-upgrade-controller/values.yaml&#34;</p>
            <details>
                <summary>v1.31.6+k3s1</summary>
                <pre>&#xA;Release published on the 2025-02-27 01:01:09 +0000 UTC at the url https://github.com/k3s-io/k3s/releases/tag/v1.31.6%2Bk3s1&#xA;&#xA;&lt;!-- v1.31.6+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.31.6, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#changelog-since-v1315).&#xD;&#xA;&#xD;&#xA;## Changes since v1.31.5+k3s1:&#xD;&#xA;&#xD;&#xA;* Correct the k3s token command help [(#11685)](https://github.com/k3s-io/k3s/pull/11685)&#xD;&#xA;* Jan 2025 Testing Overhaul, E2E to Docker Migration, [(#11724)](https://github.com/k3s-io/k3s/pull/11724)&#xD;&#xA;* Backports for 2025-02 [(#11732)](https://github.com/k3s-io/k3s/pull/11732)&#xD;&#xA;  * Align the CLI-reported default `--etcd-snapshot-dir` value with the actual one (`server`, `etcd-snapshot` commands).&#xD;&#xA;  * Disable s3 transport transparent compression/decompression&#xD;&#xA;  * Etcd snapshot backup/restore now supports loading s3 credentials from an AWS SDK shared credentials file.&#xD;&#xA;  * Bump klipper-helm to v0.9.4&#xD;&#xA;  * Bump klipper-lb to v0.4.10&#xD;&#xA;  * Bump spegel to v0.0.30&#xD;&#xA;  * Bump local-path-provisioner to v0.0.31&#xD;&#xA;  * Bump kine to v0.13.8&#xD;&#xA;  * Bump etcd to v3.5.18&#xD;&#xA;  * Bump traefik to 2.11.20&#xD;&#xA;  * Containerd has been bumped to version 2.0.&#xD;&#xA;  *   The containerd config templates for linux and windows have been consolidated and are no longer os-specific.&#xD;&#xA;  *   Containerd 2.0 uses a new config file schema. If you are using a custom containerd config template, you should migrate your template to `config-v3.toml.tmpl` to switch to the new version. See the [upstream documentation](https://github.com/containerd/containerd/blob/release/2.0/docs/cri/config.md) for more information.&#xD;&#xA;* Bump traefik to v2.11.20 [(#11763)](https://github.com/k3s-io/k3s/pull/11763)&#xD;&#xA;* Update to v1.31.6-k3s1 and Go 1.22.12 [(#11787)](https://github.com/k3s-io/k3s/pull/11787)&#xD;&#xA;* Render CNI dir config whenever vars are set [(#11820)](https://github.com/k3s-io/k3s/pull/11820)&#xD;&#xA;* Bump containerd for go-cni deadlock fix [(#11834)](https://github.com/k3s-io/k3s/pull/11834)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.31.6](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1316) |&#xD;&#xA;| Kine | [v0.13.9](https://github.com/k3s-io/kine/releases/tag/v0.13.9) |&#xD;&#xA;| SQLite | [3.46.1](https://sqlite.org/releaselog/3_46_1.html) |&#xD;&#xA;| Etcd | [v3.5.18-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.18-k3s1) |&#xD;&#xA;| Containerd | [v2.0.2-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.2-k3s2) |&#xD;&#xA;| Runc | [v1.2.4-k3s2](https://github.com/opencontainers/runc/releases/tag/v1.2.4-k3s2) |&#xD;&#xA;| Flannel | [v0.25.7](https://github.com/flannel-io/flannel/releases/tag/v0.25.7) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v2.11.20](https://github.com/traefik/traefik/releases/tag/v2.11.20) |&#xD;&#xA;| CoreDNS | [v1.12.0](https://github.com/coredns/coredns/releases/tag/v1.12.0) | &#xD;&#xA;| Helm-controller | [v0.16.6](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.6) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
        </details>
        <a href="https://github.com/mprochowski/k3s-cluster-gitops/actions/runs/13619744602">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

