### PR TITLE
k3s-io/k3s: bump version to v1.32.3+k3s1

### DIFF
--- a/.charts/1-infrastructure/system-upgrade-controller/values.yaml
+++ b/.charts/1-infrastructure/system-upgrade-controller/values.yaml
@@ -1,2 +1,2 @@
 kubernetes:
-  version: v1.31.7+k3s1
+  version: v1.32.3+k3s1

--- a/1-infrastructure/system-upgrade-controller/plans.yaml
+++ b/1-infrastructure/system-upgrade-controller/plans.yaml
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.31.7+k3s1
+  version: v1.32.3+k3s1
 ---
 # Source: system-upgrade-controller/templates/plans.yaml
 # Agent plan
@@ -42,4 +42,4 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.31.7+k3s1
+  version: v1.32.3+k3s1


### PR DESCRIPTION



<Actions>
    <action id="32378aa2665b229d8619fccc2da26de763ac7ea67bcad573ba096abdf76f9240">
        <h3>k3s-io/k3s</h3>
        <details id="37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f">
            <summary>k3s-io/k3s: bump version to v1.32.3+k3s1</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.kubernetes.version&#34; updated from &#34;v1.31.7+k3s1&#34; to &#34;v1.32.3+k3s1&#34;, in file &#34;.charts/1-infrastructure/system-upgrade-controller/values.yaml&#34;</p>
            <details>
                <summary>v1.32.3+k3s1</summary>
                <pre>&lt;!-- v1.32.3+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.32.3, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1322).&#xD;&#xA;&#xD;&#xA;## Changes since v1.32.2+k3s1:&#xD;&#xA;&#xD;&#xA;* Revert &#34;Add ability to pass configuration options to flannel backend&#34; [(#11867)](https://github.com/k3s-io/k3s/pull/11867)&#xD;&#xA;* Backport Docker + E2E testing PRs for 2025 March [(#11888)](https://github.com/k3s-io/k3s/pull/11888)&#xD;&#xA;* Backports for 2025-03 [(#11919)](https://github.com/k3s-io/k3s/pull/11919)&#xD;&#xA;* Bump klipper-lb image to v0.4.13 [(#11930)](https://github.com/k3s-io/k3s/pull/11930)&#xD;&#xA;* Fix syncing empty list of apiserver addresses during initial startup [(#11953)](https://github.com/k3s-io/k3s/pull/11953)&#xD;&#xA;* Update to v1.32.3-k3s1 [(#11960)](https://github.com/k3s-io/k3s/pull/11960)&#xD;&#xA;* Update Kubernetes to v1.32.3-k3s2 [(#11968)](https://github.com/k3s-io/k3s/pull/11968)&#xD;&#xA;* Fix skew test for release candidates [(#11991)](https://github.com/k3s-io/k3s/pull/11991)&#xD;&#xA;* Bump to containerd v2.0.4 [(#12003)](https://github.com/k3s-io/k3s/pull/12003)&#xD;&#xA;* Fix upgrade test container version [(#12000)](https://github.com/k3s-io/k3s/pull/12000)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.32.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1323) |&#xD;&#xA;| Kine | [v0.13.9](https://github.com/k3s-io/kine/releases/tag/v0.13.9) |&#xD;&#xA;| SQLite | [3.46.1](https://sqlite.org/releaselog/3_46_1.html) |&#xD;&#xA;| Etcd | [v3.5.19-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.19-k3s1) |&#xD;&#xA;| Containerd | [v2.0.4-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.4-k3s2) |&#xD;&#xA;| Runc | [v1.2.5](https://github.com/opencontainers/runc/releases/tag/v1.2.5) |&#xD;&#xA;| Flannel | [v0.25.7](https://github.com/flannel-io/flannel/releases/tag/v0.25.7) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v3.3.2](https://github.com/traefik/traefik/releases/tag/v3.3.2) |&#xD;&#xA;| CoreDNS | [v1.12.0](https://github.com/coredns/coredns/releases/tag/v1.12.0) | &#xD;&#xA;| Helm-controller | [v0.16.6](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.6) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
            <details>
                <summary>v1.32.3-rc4+k3s1</summary>
            </details>
            <details>
                <summary>v1.31.7+k3s1</summary>
                <pre>&lt;!-- v1.31.7+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.31.7, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#changelog-since-v1316).&#xD;&#xA;&#xD;&#xA;## Changes since v1.31.6+k3s1:&#xD;&#xA;&#xD;&#xA;* Revert &#34;Add ability to pass configuration options to flannel backend&#34; [(#11868)](https://github.com/k3s-io/k3s/pull/11868)&#xD;&#xA;* Backport Docker + E2E testing PRs for 2025 March [(#11887)](https://github.com/k3s-io/k3s/pull/11887)&#xD;&#xA;* Backports for 2025-03 [(#11920)](https://github.com/k3s-io/k3s/pull/11920)&#xD;&#xA;* Bump klipper-lb to v0.4.13 [(#11927)](https://github.com/k3s-io/k3s/pull/11927)&#xD;&#xA;* Fix syncing empty list of apiserver addresses during initial startup [(#11954)](https://github.com/k3s-io/k3s/pull/11954)&#xD;&#xA;* Update to v1.31.7-k3s1 [(#11958)](https://github.com/k3s-io/k3s/pull/11958)&#xD;&#xA;* Fix skew test for release candidates [(#11990)](https://github.com/k3s-io/k3s/pull/11990)&#xD;&#xA;* Bump to containerd v2.0.4 [(#12004)](https://github.com/k3s-io/k3s/pull/12004)&#xD;&#xA;* Fix upgrade test container version [(#11999)](https://github.com/k3s-io/k3s/pull/11999)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.31.7](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1317) |&#xD;&#xA;| Kine | [v0.13.9](https://github.com/k3s-io/kine/releases/tag/v0.13.9) |&#xD;&#xA;| SQLite | [3.46.1](https://sqlite.org/releaselog/3_46_1.html) |&#xD;&#xA;| Etcd | [v3.5.19-k3s1.30](https://github.com/k3s-io/etcd/releases/tag/v3.5.19-k3s1.30) |&#xD;&#xA;| Containerd | [v2.0.4-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.4-k3s2) |&#xD;&#xA;| Runc | [v1.2.5](https://github.com/opencontainers/runc/releases/tag/v1.2.5) |&#xD;&#xA;| Flannel | [v0.25.7](https://github.com/flannel-io/flannel/releases/tag/v0.25.7) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v2.11.20](https://github.com/traefik/traefik/releases/tag/v2.11.20) |&#xD;&#xA;| CoreDNS | [v1.12.0](https://github.com/coredns/coredns/releases/tag/v1.12.0) | &#xD;&#xA;| Helm-controller | [v0.16.6](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.6) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
        </details>
        <a href="https://github.com/mprochowski/k3s-cluster-gitops/actions/runs/14133110873">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

