### PR TITLE
argoproj/argo-cd: bump version to 3.0.0

### DIFF
--- a/.charts/0-bootstrap/argocd/Chart.yaml
+++ b/.charts/0-bootstrap/argocd/Chart.yaml
@@ -3,4 +3,4 @@ name: argocd
 description: Argo CD
 type: application
 version: 0.1.0
-appVersion: 2.14.11
+appVersion: 3.0.0

--- a/0-bootstrap/argocd/kustomization.yaml
+++ b/0-bootstrap/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 namespace: argocd
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.14.11/manifests/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.0.0/manifests/install.yaml
   - public-repository.yaml
 
 patches:


### PR DESCRIPTION



<Actions>
    <action id="dfd4e8ca281d32c42e99238c849283ac21226907f918d374d9b39c88dd90aa61">
        <h3>argoproj/argo-cd</h3>
        <details id="37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f">
            <summary>argoproj/argo-cd: bump version to 3.0.0</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.appVersion&#34; updated from &#34;2.14.11&#34; to &#34;3.0.0&#34;, in file &#34;.charts/0-bootstrap/argocd/Chart.yaml&#34;</p>
            <details>
                <summary>v3.0.0</summary>
                <pre>## Quick Start&#xD;&#xA;&#xD;&#xA;### Non-HA:&#xD;&#xA;&#xD;&#xA;```shell&#xD;&#xA;kubectl create namespace argocd&#xD;&#xA;kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v3.0.0/manifests/install.yaml&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;### HA:&#xD;&#xA;&#xD;&#xA;```shell&#xD;&#xA;kubectl create namespace argocd&#xD;&#xA;kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v3.0.0/manifests/ha/install.yaml&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;## Release Signatures and Provenance&#xD;&#xA;&#xD;&#xA;All Argo CD container images are signed by cosign.  A Provenance is generated for container images and CLI binaries which meet the SLSA Level 3 specifications. See the [documentation](https://argo-cd.readthedocs.io/en/stable/operator-manual/signed-release-assets) on how to verify.&#xD;&#xA;&#xD;&#xA;## Release Notes Blog Post&#xD;&#xA;For a detailed breakdown of the key changes and improvements in this release, check out the [official blog post](https://blog.argoproj.io/argo-cd-v3-0-release-candidate-a0b933f4e58f)  &#xD;&#xA;&#xD;&#xA;## Upgrading&#xD;&#xA;&#xD;&#xA;If upgrading from a different minor version, be sure to read the [upgrading](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/overview/) documentation.&#xD;&#xA;&#xD;&#xA;## Changelog&#xD;&#xA;### Features&#xD;&#xA;* 402802b08974bb0f1c2e417f7a190d042813c108: feat!: Logs rbac enforce by default (#21678) (@reggie-k)&#xD;&#xA;* cca748591737d568e5b976cb060b960c40bd8c14: feat!: update compareoptions default values  (#22230) (@agaudreault)&#xD;&#xA;* 029927b25ee19b3b4dfaba554014233920a2b150: feat(appcontroller): store application health status in redis by default (#10312) (#21532) (@rumstead)&#xD;&#xA;* f775e7bf28f9cd73fd8dd3f653817d4a1b10d47e: feat(appset): Add values to PR generator (#21557) (@dudo)&#xD;&#xA;* b9131c180246272ad7edf441bb80736e683187ab: feat(cmp): pass empty env vars to plugins (#18720) (#22096) (@crenshaw-dev)&#xD;&#xA;* ac50d8e1c11ce1ea4d943ae7723a1d4a8f9aa3ff: feat(config)!: exclude known interim resources by default (#20013) (#21635) (@agaudreault)&#xD;&#xA;* 910b9518e4752472a3a9594b3a6b6b4f9796be78: feat(controller): enable batch event processing by default (#22338) (@crenshaw-dev)&#xD;&#xA;* 7edaef54d456a9f5f59760f0bb4958e41a43fd94: feat(helm): upgrading helm to 3.17.0 (#21722) (@rumstead)&#xD;&#xA;* 3d2c010dbe9c7275ad2cbae02ab9b675ef3058d3: feat(hydrator): handle sourceHydrator fields from webhook (#19397) (cherry-pick #22485) (#22753) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* 88e43cb730a26e58c52dbdf9e7df6cc5aa4801be: feat(kubectl): upgrading kubectl to 1.32.1 (#21724) (@rumstead)&#xD;&#xA;* c6757573ae350c37ce601ab9b7787fd9b33164af: feat(kustomize): support --include-templates for labels (#15283) (#22069) (@crenshaw-dev)&#xD;&#xA;* 6f9389c2ea6497d5285cde9e16e7e2b1bdcdb866: feat(log): support match case in pod log search (#21919) (@linghaoSu)&#xD;&#xA;* feb7097fc9808bd725b26d012bf04121e5c59995: feat(metrics): add more kubectl metrics (#21720) (@crenshaw-dev)&#xD;&#xA;* 606bd5b04393a06461d007d066da0f0d4a6c6d95: feat(rbac)!: disable fine-grained inheritance by default (#19988) (#20671) (@fffinkel)&#xD;&#xA;* e3bd56972d98d139e79df85d930ac5dd441b3834: feat(server): make deep copies of objects returned by informers (#22173) (#22179) (@rumstead)&#xD;&#xA;* 72962014b53970b7eae3922ee0458fdc6d896f92: feat(ui): Added link to start page in argo logo (#21461) (@surajyadav1108)&#xD;&#xA;* 6d2792896598a39828b8716ba8437c1b50772cf8: feat(ui): highlight log lines by pod name (#21001) (@aali309)&#xD;&#xA;* b8508f29162b91a547ec94b25df8e1011c6576fb: feat(ui): rename filter message status on SYNC STATUS view (#21061) (@aali309)&#xD;&#xA;* 55f8a434d06ee335b195783a0a83c6a7c8dd3078: feat(ui): split arrays in yaml to fix ambiguous collapse when array items have nested objects (#21064) (@aali309)&#xD;&#xA;* 0fab3cfeec9c68a4d762679b6cd8b5214d2ea2f3: feat(ui): support display sync wave (#20614) (@linghaoSu)&#xD;&#xA;* 922c9e9cccf5e3652ba1c6934d670d1c9e3c3920: feat(ui): support filter repo when input (#21451) (@linghaoSu)&#xD;&#xA;* 89c48172138eabe03b062989f5928ae9a19d5dc7: feat: Add support for Azure workload identity for Git and OCI repositories. (#21118) (@jagpreetstamber)&#xD;&#xA;* f9ffb6ae35b23f2a47fb33b2017ae1ab6cb89efb: feat: Added env reference objects to manifests for otlp.attrs (#21563) (@almoelda)&#xD;&#xA;* 0973409273918eebe0f8ff436056261cc477bfc7: feat: Kustomize ignore missing components (#18634) (#21674) (@bradkwadsworth)&#xD;&#xA;* 74b35322a2639ad027c2fada1e675704faab9952: feat: Make certain Status panel items look more &#39;clickable&#39; (#19698) (#22232) (@keithchong)&#xD;&#xA;* c0b278738cd75621a1b3ed2128acfe19cb548700: feat: Support kube 1.32 (#21805) (@sivchari)&#xD;&#xA;* d301b40c6b7b4061bf1741e8a155659c08856bbe: feat: Upgrade notifications engine (#22273) (@sivchari)&#xD;&#xA;* c9c40684b79aea7deed03de8df9de77768b971a6: feat: add AND operator opt-in option for sync windows matches (#16846) (@adriananeci)&#xD;&#xA;* f258c450b8d115df8185d103aebfeffbebdef8a6: feat: add `ARGOCD_APP_PROJECT_NAME` to the build environment (#15185) (#21586) (@MacroPower)&#xD;&#xA;* c71dd1a9e670844e4a72d3851185cb61c3ddbec7: feat: add a check for user defined role referential integrity (#21065) (@devopsjedi)&#xD;&#xA;* 8044d6849273bb6e3ad59ad35d94d8300e43c733: feat: add bearer token auth  (#21462) (@reggie-k)&#xD;&#xA;* fa0b5f56abd38ee99a10dfd665dae3faf445e31d: feat: add force promote actions for Numaplane rollouts (#22141) (@dpadhiar)&#xD;&#xA;* e4311d830926aba78d6ae1f69d4572df261fba91: feat: add name and labels in cluster metrics (#17870) (#18453) (@flbla)&#xD;&#xA;* ecb9dbac426351f9079517f6af3c5ee653ec91b3: feat: add support for azure workload identity in Microsoft Entra SSO (#21433) (@jagpreetstamber)&#xD;&#xA;* 951d9d3f17d53e79368886882949504c68e94070: feat: add the `--redis-compress` as the global flag to set redis compression. (#21786) (@nitishfy)&#xD;&#xA;* 561cbef5cc360a2f8b750d6a35d117cfcfc6c5b7: feat: checking user defined roles and policies for referential integrity (#20825) (#22132) (@devopsjedi)&#xD;&#xA;* d23e6ac79bb95a911b988551ba33bfc9939c5f18: feat: configurable log timestamp format (#21478) (@crenshaw-dev)&#xD;&#xA;* c09e6fa6ad2f48017e2d66e65a679226414e6653: feat: improve StatefulSet immutable field error messages (#21209) (@aali309)&#xD;&#xA;* 1698370363f8b5ca8df186d84012906c23a20390: feat: replace spdy with websocket for portforward and pod exec #21517 (#21518) (@maoqide)&#xD;&#xA;* 3e09f946f4f229534bbcac7cf238546812e7a817: feat: resource customization for CustomResourceDefinition (#21416) (@almoelda)&#xD;&#xA;* 6b002a51067387055c8cc7226c0c6b8a1e19121c: feat: upgrade to v1.32.2 (#22168) (@sivchari)&#xD;&#xA;* fbd7f29056458deed52816d9cad3dc0139fe3656: feat: use errors.Join for debuggable (#22235) (@sivchari)&#xD;&#xA;* dbdc1e737ab81184aa20a12430da69462fe138ff: feat: use log format config for klog (#5715) (#21458) (@crenshaw-dev)&#xD;&#xA;### Bug fixes&#xD;&#xA;* 46bfc10e4d4e84ec75245f554b2c9d0ed2348ab4: Revert &#34;fix: Graceful shutdown for the API server (#18642) (#20981)&#34; (#21221) (@pasha-codefresh)&#xD;&#xA;* c6b00007f2b2c05093f34c89f69e2de34f6815a9: fix(actions): don&#39;t run empty Lua scripts (#22084) (#22161) (@crenshaw-dev)&#xD;&#xA;* e6f94f227cf92e82652e79bd19ec91878da4e912: fix(appcontroller): selfhealattemptscount needs to be reset at times (#22095) (@blakepettersson)&#xD;&#xA;* 079341c65cde946d260a1cb96324ce0be53f2b6b: fix(applicationset): ApplicationSets with rolling sync stuck in Pending (#20230) (@Fsero)&#xD;&#xA;* f6a84a470d1f8241207280a8d334ec9cb021443f: fix(appset): Reconcile appset only once when appset is refreshed (fix 21171) (#21172) (@dacofr)&#xD;&#xA;* f3509d2f8ac6c9067d53c3a45b6ccc66ab02ead3: fix(appset): dont requeue appsets on status change (#21364) (@rumstead)&#xD;&#xA;* e852142fb9467d32cd580b633e744d34bd875adf: fix(appset): events not honouring configured namespaces (#21219) (#21241) (@eadred)&#xD;&#xA;* e44ae96c0706ca15c8a7cd80ba352f2e19e4857e: fix(appset): generated app errors should use the default requeue (#21887) (#21936) (@rumstead)&#xD;&#xA;* 922dd771e36973d8d1cc69ad14dd9e3002ab313a: fix(appset): improve git generator repo credential fallback (#21167) (@blakepettersson)&#xD;&#xA;* 55aab6efb6e8dd510050e23b876ff25792e39e54: fix(appset): reverted Gitlab SCM HasPath search and consider 404 errors as file not found (#16253) (#21597) (@prune998)&#xD;&#xA;* 37a7231bd3fe5c28470e1fbb46f34b3bdef98632: fix(appset): update gitlab SCM provider to search on parent folder (#16253) (#21491) (@prune998)&#xD;&#xA;* 06bd2ad10f5124ba98364a85ff1ec42947d34706: fix(ci): all version bump changes go in the PR (#21409) (@crenshaw-dev)&#xD;&#xA;* 2933154a5c05c45f2c5405e87973092cd0e03d82: fix(ci): get correct previous version, fail workflow if not (cherry-pick #22376) (#22377) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* 15046b992e27856993d88d4609d3433b1948f6b3: fix(ci): handle major versions in compatibility table generator (cherry-pick #22370) (#22371) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* 43d2a3d93772cab395e611a75ef6026a96282915: fix(ci): proto references bump (#21391) (@crenshaw-dev)&#xD;&#xA;* 05c76253f0574c3a98134bca6319a71f257f5705: fix(ci): updating action-gh-release after upstream fix (#21407) (@rumstead)&#xD;&#xA;* eb6732ec9e3a69cd9b28fb858471403f531cb3a6: fix(ci): use pinned Helm version for init-release (#22164) (#22165) (@crenshaw-dev)&#xD;&#xA;* 6e4c8fd53d8fa9589ff6663b40b45058869329d5: fix(ci): use tags instead of branches (cherry-pick #22372) (#22373) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* 99cd3c765015f04b5c6bd2265457a1809c6490ac: fix(cli): add flags to admin import for retrying updates on conflicts and skipping resources with specific labels. (#21694) (@ashutosh16)&#xD;&#xA;* 85684a8919104ce0e286837d771a28437aeb160a: fix(cli): application cannot be refreshed when invalid and hangs (#21615) (@agaudreault)&#xD;&#xA;* eb6dd46e194974d6216d8def5f80f10e127dd0dc: fix(cli): ignored resources should not be pruned during restore (#21894) (@agaudreault)&#xD;&#xA;* 9c443b65013945c1cbae77b0ff24f2c07200529f: fix(cli): improve performance for admin export/import cmd (#22322) (@agaudreault)&#xD;&#xA;* 546383a8e56355f90530c00a78385444efb943b1: fix(cli): log correct error message when updating a cluster that is not present (#22190) (@nitishfy)&#xD;&#xA;* 613d06d0b1f258bfe8dd7f5aa5a57d9b231ddb22: fix(cli): use correct CA when adding kube-public clusters (#21326) (#21327) (@aminarefzadeh)&#xD;&#xA;* f2ee9a62d2120abd2ba8eed1915ecb0011bcd0c9: fix(cli): wrong variable to store --no-proxy value (#21226) (@the-technat)&#xD;&#xA;* a8ce6772b8b8f4a73b99fed180bbbcf2be0fea51: fix(controller): always set health.status.lastTransitionTime (#22665) (cherry-pick #22666) (#22667) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* 1a9f22625db5d5c968031e0a32c2ec1f6ce8ce60: fix(controller): rename cluster batch param and add to argocd-cmd-params-cm (#21402) (@crenshaw-dev)&#xD;&#xA;* d54ae98b20a7700bb143804d6029a41c057bc0c2: fix(controller): wrong tracking annotation for malformed resources (#22325) (@crenshaw-dev)&#xD;&#xA;* b4a63aeba87d5d4d7b0c72a608fe873abc8be7f6: fix(dex): always request `federated:id` scope (#17908) (#21726) (@agaudreault)&#xD;&#xA;* ad09b9c744853d3dad0a7dbef27b49258dda6266: fix(docs): 2.14 upgrading docs (#21756) (@rumstead)&#xD;&#xA;* 43822815f76cd5c0bd6989029f20f56b787f2420: fix(docs): Fix syntax in e2e test docs (#21796) (@pjiang-dev)&#xD;&#xA;* 8545d214b6cf934ed1476f14a790657730e8bcc3: fix(docs): update --auth-token description in argocd_appset_update.md to account for environment variable (#22350) (@chengfang)&#xD;&#xA;* 68d60cd09269e0f81b09188c8eee30f73d0f5720: fix(docs): update mkdocs for upgrade guide (#21768) (@rumstead)&#xD;&#xA;* 7c7dda0e93c0745a1d50aa399b6f7caca3108027: fix(grafanadashboard): add memory units to panels showing memory usage (#22078) (@BWagenerGenerali)&#xD;&#xA;* 9429275a91cbf78e81703e35bca25ce97f02e67c: fix(hydrator): UI nil checks (#21598) (@crenshaw-dev)&#xD;&#xA;* 3baca9b6960691435e039dd756ae122a272ebd42: fix(hydrator): don&#39;t get cluster or API versions for hydrator (#21985) (@crenshaw-dev)&#xD;&#xA;* 35009a7d1c278c5f609160651a843d17fcf1b8ef: fix(hydrator): don&#39;t use manifest-generate-paths (#22039) (#22015) (@crenshaw-dev)&#xD;&#xA;* 8a97c1d138b4c7fe0c19af284f753b69cb4dda95: fix(hydrator): refresh by annotation instead of work queue (#22016) (@crenshaw-dev)&#xD;&#xA;* d1574c204f8213a684962520fd8525827008dae0: fix(rbac): Add rights on applicationsets for the application controller (#20352) (@OpenGuidou)&#xD;&#xA;* 13b7b09668307f8365346dd74c7bd032e216fecf: fix(settings): race condition on settings configMap (#21225) (@agaudreault)&#xD;&#xA;* 416b7d0c32947b0adc7b85893c8d3901b59146e5: fix(test): Use t.Fatal instead of os.Exit in tests (part 1) (#21003) (#22114) (@andrii-korotkov-verkada)&#xD;&#xA;* 2afcb6f107deada4210dec8f44b2f57cd95f93db: fix(test): delete CRD between tests, install CRD before syncing CRs (#22299) (@crenshaw-dev)&#xD;&#xA;* fa747f987c83d6a761a6745a1b809ce1c741a111: fix(tests): Improved the e2e tests for app sync with impersonation feature (#21792) (@anandf)&#xD;&#xA;* b88ad57986aa75af414f4316ad4a74f574cb157b: fix(ui): Added SSV option to helm type repos (#22006) (@surajyadav1108)&#xD;&#xA;* 544aea18c32b34eac523791e7e2ef186abbd6daf: fix(ui): Cannot add an app that has both name and server destination (#21440) (@rpelczar)&#xD;&#xA;* 1ce0123fa57a66998858b40b416e23b904354dda: fix(ui): Group Nodes breaks Kinds counts / views (#21337) (@surajyadav1108)&#xD;&#xA;* 71c7700f2eb4578e23b59c082c19c0f784e36dbc: fix(ui): Show error message when max pods to view logs are reached (#21725) (@pjiang-dev)&#xD;&#xA;* 854c62fc70bbc6b962c97b232cdb962e56086817: fix(ui): Solve issue with navigating with dropdown from an application&#39;s page (#21737) (@amit-o)&#xD;&#xA;* b6e6104dbc131d03b5f3a7fd7b8f64c5de48e775: fix(ui): avoid spurious error on hydration (#22506) (cherry-pick #22711) (#22715) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* 38b0fd5cd4cb675a9e5708d95c949192dfbd0f8c: fix(ui): columns-adjusted for kind and Namespace in sync details. (#21038) (@surajyadav1108)&#xD;&#xA;* ebeae20ff40aef654a0cfbffdade8aaf03d012c1: fix(ui): fix bearerToken validate in helm connect page (cherry-pick #22791) (#22798) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* bfb04ddf3e9735a7a1e06c5b3c44c4de2f6ed9e8: fix(ui): parameter tab null ref w/ hydrator (#22097) (#22131) (@crenshaw-dev)&#xD;&#xA;* e2e6faa3b53ef50aa3aac47a245410ac0f0c8d73: fix(ui): prevent parameter editor from resetting when props update (fixes #14351) (#21625) (@k4r1)&#xD;&#xA;* 4202168c4424609698169dc0530168377838f9db: fix(ui): reduce rerender in pod log view (#22241) (@linghaoSu)&#xD;&#xA;* 0d34340c20b6bb1770f4e0fa97de49848e4a0a7a: fix: 21062 Support GitLab &#34;System Hook&#34; webhooks for ApplicationSets (#21243) (@eadred)&#xD;&#xA;* 911a9c6776afccb98a0c0f73bd749497c3a66ab4: fix: Add proxy registry key by dest server + name (#21791) (@leoluz)&#xD;&#xA;* a444a05e8f32368222c4104c756997fd6bdf86d9: fix: AppSet PullRequest and SCM generators get 401 from GitHub without tokenRef (cherry-pick #22737) (#22744) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* ffbf9d5911e9fd747d879987060162e108c70b2b: fix: AppSet PullRequest and SCM generators get 401 from GitHub without tokenRef (manually signed off cherry-pick #22737) (#22763) (@reggie-k)&#xD;&#xA;* f39b425facb2a4fdc05193c85b51d145b0124d1c: fix: CVE-2024-21538 upgrading the indirect dep cross-spawn to greater than 7.0.5 (#21259) (@nmirasch)&#xD;&#xA;* 644315ace198159ccb0dacc31ebac906a8b1ff12: fix: Change applicationset generate HTTP method to avoid route conflicts (#20758) (@amit-o)&#xD;&#xA;* d6a04a364235b913f89a39a528abb2fab41bfa95: fix: Check for semver constraint matching in application webhook handler (cherry-pick #21648) (#22507) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* 1905d127a57c4cc30b9818c5bc08d2bee9a4bbc0: fix: Check placement exists before length check (#22060) (#22057) (@dhaiducek)&#xD;&#xA;* 0d2471b3f93ace800cbe7af6cf718e922a6b1149: fix: Enable service account token automount for haproxy (#22226) (cherry-pick #22353) (#22406) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* 8841b0dd1d943b333e30c1d1de02dad77530e203: fix: Fix calculating SelfHealBackOff delay when exceeding maximum (#20976) (#20978) (@mrysavy)&#xD;&#xA;* 4dcabb933e54f21cd922e7450c5b46ae86b08793: fix: Fix link about http middlewear and  add adopter hetao101 (#21802) (@wanghonglei5181)&#xD;&#xA;* e3b333a8609134daa570c2b098134ef26e35ffa4: fix: JSON format (#22237) (@sivchari)&#xD;&#xA;* 5b79c34c72300e6e2e6336051ce6992f6d54011c: fix: New kube applier for server side diff dry run with refactoring (#21488) (#21749) (@andrii-korotkov-verkada)&#xD;&#xA;* a8f646e430781a3b1707d3bedde8ea4c8cd76e9a: fix: Notifications on-deployed would now be delivered if sync didn&#39;t change the health status of the app in a process (#22203) (#22204) (@andrii-korotkov-verkada)&#xD;&#xA;* 7b1ed5218ae864d60792b7f424c13b7375a141ff: fix: On deployed trigger must consider race between last transition time and sync finished time (#9070) (#21944) (@andrii-korotkov-verkada)&#xD;&#xA;* f075c5acd3ea3fc642536b70c00a049186086908: fix: Only port-forward to ready pods (#10610) (cherry-pick #22794) (#22825) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* ed3cc488471a26d1f342eaf92a62a2731ac77ebb: fix: Policy/policy.open-cluster-management.io stuck in progressing status when no clusters match the policy (#21296) (#21297) (@mbaldessari)&#xD;&#xA;* 43e594104212bae8ec15bacf7f31c504061842ee: fix: Race condition occurs during initial sharding (#22264) (@kahou82)&#xD;&#xA;* 74244323f8495a2369b79dc0a26655b711d1afa5: fix: Rephrased sentence to a meaningfull one (#22113) (@babugeet)&#xD;&#xA;* bfd72b42dff5e0b05d3748ff8ea1c20d1561976a: fix: Revert &#34;fix: Race condition occurs during initial sharding (#22264)&#34; (#22354) (@andrii-korotkov-verkada)&#xD;&#xA;* f542ae51588405065557e8ede710a50042cf529e: fix: Revert &#34;split arrays in yaml to fix ambiguous collapse when array items have nested objects (#21064)&#34; (#22099) (#22128) (@andrii-korotkov-verkada)&#xD;&#xA;* 4a1d0f3af5cb1f093b3b17a82093f48f36959b99: fix: Switch default logging to JSON (issue: 20897) (#21656) (@teddy-wahle)&#xD;&#xA;* 0ed7c5618f727edb7aead256ff828def6da15b3e: fix: Unable to edit http repo credentials from ArgoCD UI (#22065) (@aali309)&#xD;&#xA;* e8a3f7aa33c05b1e2e9011cadaa2d240f811a4ca: fix: Update argo-ui dependency to pull in OCI icon (#18646) (#21698) (@keithchong)&#xD;&#xA;* 376e8d52605e8b18fc46e830892fe570968a30a8: fix: Update haproxy version to match the chart (#22226) (#22236) (@andrii-korotkov-verkada)&#xD;&#xA;* 9f81cd47980805ed9b590ab418b121e33b8d5b8b: fix: Use ARGOCD_SERVER for default value (#21930) (@sivchari)&#xD;&#xA;* 62ec9fef36b0e998e202405d70adb93ab3d78771: fix: Use t.Fatal instead of os.Exit in tests (part 2) (#21003) (#22187) (@andrii-korotkov-verkada)&#xD;&#xA;* c93924b3ccabdf769510db58b7684e3dc8a2d20c: fix: Wait for Subscription resources to reach AtLatestKnown (#21425) (@vinzent)&#xD;&#xA;* e6e92552167ad10ce7ca45c02f5534af6741e710: fix: correct lookup for the kustomization file when applying patches (#22024) (@nitishfy)&#xD;&#xA;* f548fd7a247a0311ac31f9df5acf135fd44f401b: fix: correctly set compareWith when requesting app refresh with delay (fixes #18998) (#21298) (@shenxn)&#xD;&#xA;* 5d131c5251e5c2903823b2d5cc439ec30092c263: fix: do not exclude APIService resources (cherry-pick #22586) (#22587) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* b2e875323c7ce364ac19f49e65eaeca739ee8981: fix: do not normalize resource tracking on live crds (cherry-pick #22722) - cherry-pick 3.0 (#22735) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* d183d9c614d05979f1327a554942a9e656f1c2ec: fix: dynamic cluster distribution issue 20965, update the shard… (#21042) (@ivan-cai)&#xD;&#xA;* 49a4b7f14fb6a006d76446a1b44ad5309c8ebc2d: fix: fetch syncedRevision in UpdateRevisionForPaths (#21014) (#21015) (@toyamagu-2021)&#xD;&#xA;* 563ccb20c7f9e246c1ac790f055fe2ce14e35fa4: fix: fix KustomizeImage Match function to pass added unit tests (#21872) (@chengfang)&#xD;&#xA;* 6959e54f06688bb5409305c1b62e4c6625af40aa: fix: have argocd server pass the appLabelKey for proper caching (#22186) (@gdsoumya)&#xD;&#xA;* 87671f55c512b306451855b4a4b4f2c4c2762045: fix: ignore prune=false resources from PruningRequired count  (#21941) (@gdsoumya)&#xD;&#xA;* 75cb7fc42de2b6aa4e58c899a28a3a07d88cf671: fix: issue 22206 - fixes overlapping lines in logs by increasing line height (#22207) (@GP3-RS)&#xD;&#xA;* eed70eed6ef38bb64cfa950dc5fcae37c244ce76: fix: login return_url doesn&#39;t work with custom server paths (#21588) (@alexmt)&#xD;&#xA;* b600c5ec7d6bf5f84268a0495b92e4b6fe942aff: fix: make codegen permissions (#21667) (@dudo)&#xD;&#xA;* c7e02eefdd6ea3e9ab84f4014724175dca0edac5: fix: make test fails with exec format error (#21630) (@reggie-k)&#xD;&#xA;* 85c6d267ba9fd1e62e9f77ffdee7affc9ddd3f1f: fix: override sub with federated_claims.user_id when dex is used (#20683) (@aali309)&#xD;&#xA;* 11b866578fa6aa6b115378bfb81cc800212261cd: fix: remove kustomize binary from git (#21526) (@rumstead)&#xD;&#xA;* 6fea0084478853777a43acfcd0165dfc137c68d7: fix: remove project from cache key for project scoped credentials (cherry-pick #22712) (#22817) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* 686964daaa468bf4bf0ae76f3d84ed69a308723e: fix: removed null security context from redis-ha values.yaml to placate helm 3.17.1 (#22035) (@reggie-k)&#xD;&#xA;* 6f383276477ec00b04644322885fb44b4949b299: fix: resolve the failing e2e appset tests for ksonnet applications (#21580) (@reggie-k)&#xD;&#xA;* 806c5f6b6da75b74219c2317a3a124c6c9276841: fix: return cluster URL in error message, not full cluster object (#22094) (@crenshaw-dev)&#xD;&#xA;* 94b34f88ecefb7c81bcd5c8a9489e8dd4c46b69f: fix: upgrade x/crypto to v0.35.0 to solve CVE-2025-22869 (#22048) (@gergelyfabian)&#xD;&#xA;### Documentation&#xD;&#xA;* e3caebae56c6f6c1a7ce3a6bb9f4b3543e8a31e7: docs(hydrator): document signature verification limitation (#21504) (@crenshaw-dev)&#xD;&#xA;* 04a1608643b8c4843fbc07c02bb7dcc21a83bccf: docs: 3.0 release date on May 06 (#22189) (@reggie-k)&#xD;&#xA;* fdf9a305b394e9dc65463781b66f50aeb55b590c: docs: 3.0 upgrade guide (#21457) (@crenshaw-dev)&#xD;&#xA;* c687247ce84db325ce100f43ce05f18ae86b2c17: docs: Add LY Corporation to list of users (#21592) (@Asuforce)&#xD;&#xA;* 898a126f105e54f11db49aa73dc7a6b6ac575e78: docs: Add section on how to lock down/restrict the default project (#21757) (@dag-andersen)&#xD;&#xA;* 3f74b24c0a2580594fb08d0970e144681e1d78c0: docs: Adding Argo CD CLI plugin support proposal (#19624) (@christianh814)&#xD;&#xA;* 7ba7fc028ec328d09973b2b0fea375464436efb9: docs: Auto Sync toggle does not work for Applications created with an ApplicationSet (#21577) (@revitalbarletz)&#xD;&#xA;* f27515783a85f120a497f89e2484a73c0929c2c6: docs: Document Helm 3.17.1 breaking changes (#22283) (@reggie-k)&#xD;&#xA;* c4183aad7657bef4eddc26776e5c33c7d69bf84b: docs: Document askpass socket sharing between reposerver and cmp sidecar (#22083) (@peschmae)&#xD;&#xA;* d19b02dcd0f3223de03d81054d4ecaa265a839ca: docs: Ensure Argo CD Hydrator branch prefix consistency  (#21836) (@dag-andersen)&#xD;&#xA;* 167e122eba964f2c61d41745f7ffcf3aae0964e2: docs: Fix typo code-gen/codegen contributors-quickstart.md (#21922) (@fe-ax)&#xD;&#xA;* dc3286730af6bc9537c4b63181127e163a47492e: docs: Fix typos and grammar in tls.md (#22229) (@todaywasawesome)&#xD;&#xA;* 87539aa55870f3a4f3a824b9ae447a9c0af2e98e: docs: Surface blog with (actual) release notes better (#21572) (@revitalbarletz)&#xD;&#xA;* 499f74dc27e288220a6c1476db8894ba23d2c28b: docs: Update USERS.md (#22093) (@mreparaz)&#xD;&#xA;* 961147d3874cf90a142c08d912d62cdb555fea14: docs: Update sync-kubectl.md - Correct kubectl command for a sample (#22030) (@taeyeopkim1)&#xD;&#xA;* 1823d8fcd27b1249d4834925b3ef9878df5bb11c: docs: add applicationset controller doc to preserve annotations and labels (#22008) (@leoluz)&#xD;&#xA;* 77ff8f0dd48e49f1b558c6a2cc0be901735c192e: docs: add missing word (#21428) (@nitishfy)&#xD;&#xA;* 2d10d4e78567afcbb18db5e60f3fe48583a7e5b9: docs: add mkdocs configuration stanza to .readthedocs.yaml (#21475) (@reggie-k)&#xD;&#xA;* 975e966e26a3b86bfe129944b0a8b093db0030f5: docs: add more info on what `login --core` does (#21487) (@nitishfy)&#xD;&#xA;* db8d2f08d926c9f811a3d4f26d2883856e135e38: docs: add note about comments in policy.csv files (#21339) (@morremeyer)&#xD;&#xA;* 9fd6beea7f07d0b83e154d6fe20f9db00dcc50e0: docs: add statusbadge.url override information (#21529) (@tobiasehlert)&#xD;&#xA;* 1645d576fd0c8e9e822037d5ff6dd4469aeaf0ff: docs: add wildcard globbing example to docs (#21429) (@LRost)&#xD;&#xA;* 65664ce5f302f46e765ea5da89109145b8b543c6: docs: clarify wording on cluster secrets (#21865) (@todaywasawesome)&#xD;&#xA;* 7327093b66274a99661eed2f1947a22c6f4d9bfb: docs: custom resource action UI tweaks (#22202) (@crenshaw-dev)&#xD;&#xA;* 8a752a56d6e6279f33af658176c1a57a0ac441c6: docs: document bearerToken in repo example doc (#22195) (@crenshaw-dev)&#xD;&#xA;* 8d12e352f4db7dea923dc5a37da8ef6c5ef9d4c2: docs: document logs RBAC enforcement remediation (#22285) (@reggie-k)&#xD;&#xA;* f63f5f954ea6f2f9ebf37b40d8d25e9dcc3ac259: docs: document source hydrator maturity (#21969) (@crenshaw-dev)&#xD;&#xA;* c32afb4ee28dc224808d306c1aa9db4017d34af3: docs: endorse secrets operators, caution against plugins (#21629) (#21631) (@crenshaw-dev)&#xD;&#xA;* 05cde71efc9297b8b620ae4d6f4fcfa1c2fb7a0b: docs: fix aws sso documentation (#20681) (@chansuke)&#xD;&#xA;* 40d86e7b184f257da368b446c266e766c8d7b18e: docs: fix broken link in notifications overview (#21684) (@jeanmorais)&#xD;&#xA;* ce819128f9f46b9d58b73aac75d39ae0d4d04eda: docs: fix project role docs (#21832) (@klemmster)&#xD;&#xA;* bd1018af5eeb5b4ef54ebb95d04895e987257b40: docs: fix tmp path and document Rancher caveat (#22252) (@crenshaw-dev)&#xD;&#xA;* 3c3410cf5d76afd06666a11adf9678479c3c7258: docs: fix typo in declarative-setup.md (#22256) (@muffl0n)&#xD;&#xA;* 846503bb0e7c9cd994586395192cac17f05a37ff: docs: note idle connections issue for cluster namespaces (#21978) (@crenshaw-dev)&#xD;&#xA;* 1a56ea7417eb25494d7f6c00ecb47be17d546c1a: docs: remove branch var outdated from the cluster param (#21549) (@afzal442)&#xD;&#xA;* 070287cecc632bd0a9b7ed00f20aa9d789e78e2d: docs: update contributors guide with repo clone and make targets (#21473) (@reggie-k)&#xD;&#xA;* 9f8d68f07b53af26f228c5180b2affde14c2af87: docs: various wording fixes for 3.0 migration guide (#22343) (@todaywasawesome)&#xD;&#xA;### Dependency updates&#xD;&#xA;* f2c509301378d4524dab03add2ea4720b7740dd1: chore(deps): bump @types/selenium-webdriver from 4.1.27 to 4.1.28 in /ui-test (#21414) (@dependabot[bot])&#xD;&#xA;* e6b110d05b7c3e2337a8fe46edd9c610e5ca6a79: chore(deps): bump SonarSource/sonarqube-scan-action from 4.1.0 to 4.2.1 (#21230) (@dependabot[bot])&#xD;&#xA;* cb135fdd0d6bfa23036cf04f33e06fde5ff7946c: chore(deps): bump axios from 1.7.4 to 1.8.2 in /ui-test (#22247) (@dependabot[bot])&#xD;&#xA;* 5e30858705d830e41ab006f263afde509f71bf10: chore(deps): bump bitnami/kubectl from 1.31 to 1.32 in /test/container (#21234) (@dependabot[bot])&#xD;&#xA;* 812a9da62a0a7b70fc9f48d427d6ec750a78ae5e: chore(deps): bump chromedriver from 131.0.3 to 131.0.4 in /ui-test (#21268) (@dependabot[bot])&#xD;&#xA;* c3600d240a42a4708ec65091ffb23689b4513f85: chore(deps): bump chromedriver from 131.0.4 to 131.0.5 in /ui-test (#21415) (@dependabot[bot])&#xD;&#xA;* 742d45a1f5ee49292680887dbab57543e952bbc9: chore(deps): bump chromedriver from 131.0.5 to 132.0.0 in /ui-test (#21512) (@dependabot[bot])&#xD;&#xA;* cdb7995693211e378bfd8ab49b28b43c33fcaf5e: chore(deps): bump chromedriver from 132.0.0 to 132.0.1 in /ui-test (#21646) (@dependabot[bot])&#xD;&#xA;* 6c64d5ff552efcb63409e3ba077b9b37f576ba58: chore(deps): bump chromedriver from 132.0.1 to 133.0.2 in /ui-test (#21916) (@dependabot[bot])&#xD;&#xA;* c47152d0174a56bc30e22fae795fcd06648367e8: chore(deps): bump chromedriver from 133.0.2 to 133.0.3 in /ui-test (#22018) (@dependabot[bot])&#xD;&#xA;* 2cefcc5a364b4bc4ba2eaf2a4c3d960d88d8ae34: chore(deps): bump chromedriver from 133.0.3 to 134.0.0 in /ui-test (#22218) (@dependabot[bot])&#xD;&#xA;* a45f71576314245beb297880c1060f8547596c32: chore(deps): bump chromedriver from 134.0.0 to 134.0.2 in /ui-test (#22307) (@dependabot[bot])&#xD;&#xA;* 5207508871d35ca7fd0cc429722b71b3a1d2e2bb: chore(deps): bump code.gitea.io/sdk/gitea from 0.19.0 to 0.20.0 (#21464) (@dependabot[bot])&#xD;&#xA;* 8ce1c33ce6b5a45ca68f70119fcb8333ab6f6e26: chore(deps): bump docker/setup-buildx-action from 3.7.1 to 3.8.0 (#21210) (@dependabot[bot])&#xD;&#xA;* 1d47e1c7eb1371472f08c300bb9cd0ec52594c3f: chore(deps): bump github.com/Azure/azure-sdk-for-go/sdk/azidentity from 1.8.0 to 1.8.1 (#21566) (@dependabot[bot])&#xD;&#xA;* b3bf182a65acc8f09b6c2d837d6f6b3ec5fb3489: chore(deps): bump github.com/Azure/azure-sdk-for-go/sdk/azidentity from 1.8.1 to 1.8.2 (#21867) (@dependabot[bot])&#xD;&#xA;* 627da1138487912f4410c560e298d33a87bb19f1: chore(deps): bump github.com/Azure/kubelogin from 0.1.6 to 0.1.8 (#22271) (@dependabot[bot])&#xD;&#xA;* c8e1de61461eb1bd5612c10b6586760baa89172d: chore(deps): bump github.com/Azure/kubelogin from 0.1.8 to 0.1.9 (#22308) (@dependabot[bot])&#xD;&#xA;* 2a760e1fd1eb65f082d1778369613228d59d233b: chore(deps): bump github.com/alicebob/miniredis/v2 from 2.33.0 to 2.34.0 (#21232) (@dependabot[bot])&#xD;&#xA;* 219444313a06ce0de92fc52ab32ec4e93cfcb49a: chore(deps): bump github.com/aws/aws-sdk-go from 1.55.5 to 1.55.6 (#21514) (@dependabot[bot])&#xD;&#xA;* 5d84eb4ff3b7eee0c800b388b2a3a873f8f7f7d8: chore(deps): bump github.com/bmatcuk/doublestar/v4 from 4.7.1 to 4.8.0 (#21483) (@dependabot[bot])&#xD;&#xA;* 5e5ec1b021b6a38f2ad9255134e8878096d6bb6d: chore(deps): bump github.com/bmatcuk/doublestar/v4 from 4.8.0 to 4.8.1 (#21677) (@dependabot[bot])&#xD;&#xA;* 4723abd0b4911e39d7aa7c4ba721157436de15d8: chore(deps): bump github.com/bradleyfalzon/ghinstallation/v2 (#21353) (@dependabot[bot])&#xD;&#xA;* ecee599640bee639d48454b606a3b2183ffcaf54: chore(deps): bump github.com/bradleyfalzon/ghinstallation/v2 from 2.13.0 to 2.14.0 (#21955) (@dependabot[bot])&#xD;&#xA;* 635e592778d1eeba74070f887aec974e5afde664: chore(deps): bump github.com/casbin/casbin/v2 from 2.102.0 to 2.103.0 (#21330) (@dependabot[bot])&#xD;&#xA;* 84f2ab850d714de17cea9dcb621146895d98eaa2: chore(deps): bump github.com/casbin/govaluate from 1.2.0 to 1.3.0 (#21331) (@dependabot[bot])&#xD;&#xA;* b3e31ed1f4fb54b3523a19c2b4efa65b33d8b16a: chore(deps): bump github.com/coreos/go-oidc/v3 from 3.11.0 to 3.12.0 (#21383) (@dependabot[bot])&#xD;&#xA;* de40dc23347c1fc251bd47da3430b483b02b7792: chore(deps): bump github.com/coreos/go-oidc/v3 from 3.12.0 to 3.13.0 (#22347) (@dependabot[bot])&#xD;&#xA;* d29124fd3aa045bf4f3a0a8ce90ae8648e4a06f8: chore(deps): bump github.com/cyphar/filepath-securejoin (#21233) (@dependabot[bot])&#xD;&#xA;* 9a51757049dc028596d4950d7a6c7cd5a446301a: chore(deps): bump github.com/cyphar/filepath-securejoin from 0.3.6 to 0.4.0 (#21484) (@dependabot[bot])&#xD;&#xA;* eb8f05a9fd187245a3afab54a5dc8f1a616a2d58: chore(deps): bump github.com/cyphar/filepath-securejoin from 0.4.0 to 0.4.1 (#21700) (@dependabot[bot])&#xD;&#xA;* ab05f355074d8982d292d9375ac27bd83b9ba7ca: chore(deps): bump github.com/dlclark/regexp2 from 1.11.4 to 1.11.5 (#21853) (@dependabot[bot])&#xD;&#xA;* b9f49df757372822b16ff9d8871b629c41f8d11a: chore(deps): bump github.com/evanphx/json-patch from 5.9.0+incompatible to 5.9.11+incompatible (#21699) (@dependabot[bot])&#xD;&#xA;* dd366f56fa9fac94aeb04989a0164742d4e82c22: chore(deps): bump github.com/go-git/go-git/v5 from 5.12.0 to 5.13.0 (#21329) (@dependabot[bot])&#xD;&#xA;* 8200e3d315abd5f2a8cbf447bcc11585c8ddded9: chore(deps): bump github.com/go-git/go-git/v5 from 5.13.0 to 5.13.1 (#21352) (@dependabot[bot])&#xD;&#xA;* bcf2143dfee5c979d6ee97bbefcd8b82ff2c18dc: chore(deps): bump github.com/go-git/go-git/v5 from 5.13.1 to 5.13.2 (#21641) (@dependabot[bot])&#xD;&#xA;* cbef55e566f3ef2e4c5230b6f50990712590dc94: chore(deps): bump github.com/go-git/go-git/v5 from 5.13.2 to 5.14.0 (#22076) (@dependabot[bot])&#xD;&#xA;* 0b0c737af0a385d5f6618b080d8b71e6dd5a1aed: chore(deps): bump github.com/go-jose/go-jose/v3 to v4 (#22154) (@nitishfy)&#xD;&#xA;* c897e944dbeec58f111543002c080f8cc65c8793: chore(deps): bump github.com/go-jose/go-jose/v4 from 4.0.2 to 4.0.5 (#21989) (@dependabot[bot])&#xD;&#xA;* 20f0fc67860e9afb88ed4f9a5b690283753235c9: chore(deps): bump github.com/golang-jwt/jwt to 4.5.2/5.2.2 (#22464) (@crenshaw-dev)&#xD;&#xA;* 1b1735f5f0eb77ea97c625f95fb459e3e34f2595: chore(deps): bump github.com/golang/glog from 1.2.2 to 1.2.4 (#21693) (@dependabot[bot])&#xD;&#xA;* f32f69f7d28019504612f77ce3e935809290cf51: chore(deps): bump github.com/google/go-cmp from 0.6.0 to 0.7.0 (#21956) (@dependabot[bot])&#xD;&#xA;* f429352c0a223ba14adaebcb5ae31e1d245f3bdc: chore(deps): bump github.com/gosimple/slug from 1.14.0 to 1.15.0 (#21304) (@dependabot[bot])&#xD;&#xA;* 78702004612afdfecffb2d3cde16fcaed6dcebcf: chore(deps): bump github.com/prometheus/client_golang from 1.20.5 to 1.21.0 (#21915) (@dependabot[bot])&#xD;&#xA;* 0444fcdf37195e3a1be3f31b893be61471f86327: chore(deps): bump github.com/prometheus/client_golang from 1.21.0 to 1.21.1 (#22180) (@dependabot[bot])&#xD;&#xA;* 562fa065c645fddf85c447bd36043c0ba8f00655: chore(deps): bump github.com/redis/go-redis/v9 from 9.7.0 to 9.7.1 (#21957) (@dependabot[bot])&#xD;&#xA;* ca9da799d8a0ca0d8f55af45bbdce455da237645: chore(deps): bump github.com/spf13/cobra from 1.8.1 to 1.9.1 (#21889) (@dependabot[bot])&#xD;&#xA;* b17c5e4e2a6493fdc978aa0d4d8cfdca9dc17ecb: chore(deps): bump github.com/spf13/pflag from 1.0.5 to 1.0.6 (#21717) (@dependabot[bot])&#xD;&#xA;* edbce2a524967827ac96b8363bda94bac3abf156: chore(deps): bump gitops-engine to latest (#22071) (@pjiang-dev)&#xD;&#xA;* d46f224e7982c74b51f11e26fbe47a7e265b9659: chore(deps): bump gitpod/workspace-full from `230285e` to `bec45eb` (#20980) (@dependabot[bot])&#xD;&#xA;* 84b49c84cac53425d9aaae963103278ebbc8b8b2: chore(deps): bump gitpod/workspace-full from `bec45eb` to `a47a68e` (#21843) (@dependabot[bot])&#xD;&#xA;* e784c47667997d831069b52059b339471a55e712: chore(deps): bump go 1.23.5 &amp; tools (#21748) (@agaudreault)&#xD;&#xA;* 21ea59d60035bfc9477b01f0eb6c41062b680824: chore(deps): bump go.opentelemetry.io/otel from 1.33.0 to 1.34.0 (#21569) (@dependabot[bot])&#xD;&#xA;* 64569e61a1c41ed55f21bb03eb4afa3367017cf5: chore(deps): bump go.opentelemetry.io/otel from 1.34.0 to 1.35.0 (#22217) (@dependabot[bot])&#xD;&#xA;* f2490fccdd2778be609b34fb24f03793cb30aefb: chore(deps): bump go.opentelemetry.io/otel/sdk from 1.33.0 to 1.34.0 (#21570) (@dependabot[bot])&#xD;&#xA;* cce74a33e1276f1d668105236b502f05c5e67625: chore(deps): bump golang.org/x/crypto from 0.31.0 to 0.32.0 (#21397) (@dependabot[bot])&#xD;&#xA;* 50fb7bcd219d3655912f02eb22c94c660cdc1cec: chore(deps): bump golang.org/x/crypto from 0.32.0 to 0.33.0 (#21827) (@dependabot[bot])&#xD;&#xA;* bf2c4e866a85374e14f8c44a4e99785670c071bd: chore(deps): bump golang.org/x/net from 0.32.0 to 0.33.0 (#21254) (@dependabot[bot])&#xD;&#xA;* a807c0eb69c8a5744792557f54908073d5805582: chore(deps): bump golang.org/x/net from 0.33.0 to 0.34.0 (#21396) (@dependabot[bot])&#xD;&#xA;* 9783c5ea248651a86b688ee8aead29f4912b8406: chore(deps): bump golang.org/x/net from 0.35.0 to 0.36.0 (#22182) (@dependabot[bot])&#xD;&#xA;* a8b76f29519bfeddff2be7f30ef1c5e28cdf2a45: chore(deps): bump golang.org/x/net from 0.36.0 to 0.37.0 (#22209) (@dependabot[bot])&#xD;&#xA;* 0c1d218d88f3dbcae596c89ce48d6f91f7a7eb3d: chore(deps): bump golang.org/x/oauth2 from 0.24.0 to 0.25.0 (#21384) (@dependabot[bot])&#xD;&#xA;* 4641e802a49a00e742a11f66edd977e38cc94e93: chore(deps): bump golang.org/x/oauth2 from 0.25.0 to 0.26.0 (#21777) (@dependabot[bot])&#xD;&#xA;* 94d3899038ba7e28657fc5810deae265a999b6f5: chore(deps): bump golang.org/x/oauth2 from 0.26.0 to 0.27.0 (#21990) (@dependabot[bot])&#xD;&#xA;* 4c27f735596e27f23577a3530613d44dbdc6cf1d: chore(deps): bump golang.org/x/oauth2 from 0.27.0 to 0.28.0 (#22211) (@dependabot[bot])&#xD;&#xA;* 4b087089fbaa7ddb3a2c725982a9d1aa32ae1ce0: chore(deps): bump golang.org/x/sync from 0.10.0 to 0.11.0 (#21778) (@dependabot[bot])&#xD;&#xA;* 2d994038be001292fdb77cb6a53fb3db6cfcbffb: chore(deps): bump golang.org/x/sync from 0.11.0 to 0.12.0 (#22216) (@dependabot[bot])&#xD;&#xA;* 38ad4f465332b2fd5ce06d84352bba35ac176e3e: chore(deps): bump golang.org/x/term from 0.27.0 to 0.28.0 (#21382) (@dependabot[bot])&#xD;&#xA;* 73c39350311cdd830c5aa3041a88fd65ec28d747: chore(deps): bump golang.org/x/term from 0.28.0 to 0.29.0 (#21776) (@dependabot[bot])&#xD;&#xA;* 270b352cbd94fca45fb1da59d2fee474142a3dbc: chore(deps): bump golang.org/x/time from 0.10.0 to 0.11.0 (#22212) (@dependabot[bot])&#xD;&#xA;* 76d28b50ddac6e171d839b3279580658ab700ff6: chore(deps): bump golang.org/x/time from 0.8.0 to 0.9.0 (#21385) (@dependabot[bot])&#xD;&#xA;* 7d0c10e0d2f4b35cbdb350e3b0244fab10dac184: chore(deps): bump golang.org/x/time from 0.9.0 to 0.10.0 (#21779) (@dependabot[bot])&#xD;&#xA;* 6b57b163240bfc2f76cbcdf7bce2ddc4c84ee6bc: chore(deps): bump google.golang.org/grpc from 1.68.1 to 1.69.0 (#21163) (@dependabot[bot])&#xD;&#xA;* f15e1bc52c5cafd573174930917ce97de7a1f9dd: chore(deps): bump google.golang.org/grpc from 1.69.0 to 1.69.2 (#21270) (@dependabot[bot])&#xD;&#xA;* 9a02f9bc2e303158d20e9452c4e25fe0ecad91ff: chore(deps): bump google.golang.org/grpc from 1.69.2 to 1.69.4 (#21485) (@dependabot[bot])&#xD;&#xA;* b4753d8d00d2ed9295b391573cfafe9825a29e87: chore(deps): bump google.golang.org/grpc from 1.69.4 to 1.70.0 (#21657) (@dependabot[bot])&#xD;&#xA;* 2731c3f18dced20d95f402edec3aadaabf731dc8: chore(deps): bump google.golang.org/grpc from 1.70.0 to 1.71.0 (#22183) (@dependabot[bot])&#xD;&#xA;* e052670c0b74f662867071298d47f34c57316db6: chore(deps): bump google.golang.org/protobuf from 1.35.2 to 1.36.0 (#21211) (@dependabot[bot])&#xD;&#xA;* 728b31e5e9fad96a4d381c7e6712b102d8f3fa5c: chore(deps): bump google.golang.org/protobuf from 1.36.0 to 1.36.1 (#21303) (@dependabot[bot])&#xD;&#xA;* 2a497ef1fdca4125aa9d0e9435f17e4eec85d7be: chore(deps): bump google.golang.org/protobuf from 1.36.1 to 1.36.2 (#21412) (@dependabot[bot])&#xD;&#xA;* d4d671316fd89df5a2cbf26cebd9e19851b4829f: chore(deps): bump google.golang.org/protobuf from 1.36.2 to 1.36.3 (#21513) (@dependabot[bot])&#xD;&#xA;* 7333c7532715d9d3f4c47566f0d2d4d09123fff5: chore(deps): bump google.golang.org/protobuf from 1.36.3 to 1.36.4 (#21676) (@dependabot[bot])&#xD;&#xA;* 4e2902d972518f57c37b1c792fe0680cf7629ee2: chore(deps): bump google.golang.org/protobuf from 1.36.4 to 1.36.5 (#21813) (@dependabot[bot])&#xD;&#xA;* 4f179a192d90144b27cab80c001cac635d7e07e9: chore(deps): bump jinja2 from 3.1.5 to 3.1.6 in /docs (#22219) (@dependabot[bot])&#xD;&#xA;* 0dddb9e6c852ce4745b11bee8418f08e6df19e07: chore(deps): bump library/busybox from `a5d0ce4` to `498a000` in /test/e2e/multiarch-container (#21959) (@dependabot[bot])&#xD;&#xA;* d3dda53cf63fb05fdaa582aacdfd95d51617fbb4: chore(deps): bump library/busybox in /test/e2e/multiarch-container (#21486) (@dependabot[bot])&#xD;&#xA;* 780285b86e506b21621acbb0c5e1cd825dc48009: chore(deps): bump library/golang from 1.23.4 to 1.23.5 in /test/remote (#21535) (@dependabot[bot])&#xD;&#xA;* 7efd2fe2eb563e6f57e4600a0bd479d751892568: chore(deps): bump library/golang from 1.23.5 to 1.23.6 in /test/container (#21774) (@dependabot[bot])&#xD;&#xA;* 8e91ce9b2b5655b7445e6e5976df59cfb5f631e4: chore(deps): bump library/golang from 1.23.5 to 1.23.6 in /test/remote (#21799) (@dependabot[bot])&#xD;&#xA;* 9e6b28b8a28596b8a2c52cb5745083197bfaa152: chore(deps): bump library/golang from 1.23.6 to 1.24.0 in /test/container (#21866) (@dependabot[bot])&#xD;&#xA;* ee83eea7844149cd428c0c898d223a38f1bb3472: chore(deps): bump library/golang from 1.23.6 to 1.24.0 in /test/remote (#21868) (@dependabot[bot])&#xD;&#xA;* 2168221092e13439ae2ff0054025e83813f49986: chore(deps): bump library/golang from 1.24.0 to 1.24.1 in /test/remote (#22184) (@dependabot[bot])&#xD;&#xA;* 98cd061ac901cbb47d8acfb36c9f75d367c88d94: chore(deps): bump library/golang from `2b1cbf2` to `cd0c949` in /test/remote (#22020) (@dependabot[bot])&#xD;&#xA;* dbf93933654077025a44b02170ae7e674cf08f6e: chore(deps): bump library/golang in /test/container (#21533) (@dependabot[bot])&#xD;&#xA;* fe8bab0406467112e7d52466900717b8cf21bbfb: chore(deps): bump library/redis from 7.4.1 to 7.4.2 in /test/container (#21395) (@dependabot[bot])&#xD;&#xA;* f1083320a4a6f5e07062602e52cce16285d82a0d: chore(deps): bump library/redis in /test/container (#20776) (@dependabot[bot])&#xD;&#xA;* e920e71cb5a40a7a9886a540a2404db8afac748b: chore(deps): bump library/redis in /test/container (#21253) (@dependabot[bot])&#xD;&#xA;* 87a7a6eb39381c2b86ab44712664f19510fb914c: chore(deps): bump library/redis in /test/container (#21310) (@dependabot[bot])&#xD;&#xA;* 901139795d476edf026a0fd51b143b041a9ba66d: chore(deps): bump library/redis in /test/container (#21494) (@dependabot[bot])&#xD;&#xA;* 3639bfe7001ee7cd85a8c35d88a82cc1f8eed08f: chore(deps): bump library/registry in /test/container (#20775) (@dependabot[bot])&#xD;&#xA;* 683e4e0d951cf7b3fb58d70822eb2c68d19daf6c: chore(deps): bump selenium-webdriver from 4.27.0 to 4.29.0 in /ui-test (#22117) (@dependabot[bot])&#xD;&#xA;* 871ed62000ff9676c109359b95f7d08372e6a5cb: chore(deps): bump sigs.k8s.io/controller-runtime from 0.19.3 to 0.19.4 (#21411) (@dependabot[bot])&#xD;&#xA;* 527ef92c30f1c2d5d5cc2e5a3cc9d0f14ee2ba55: chore(deps): bump sigs.k8s.io/structured-merge-diff/v4 from 4.4.4-0.20241211184406-7bf59b3d70ee to 4.6.0 (#22181) (@dependabot[bot])&#xD;&#xA;* e18b4d7ac8c3979d5d8fdc014532a9daef2f7d76: chore(deps): switch to new expr package (#21982) (@crenshaw-dev)&#xD;&#xA;* 36d563a3c289fd099aa195666a33cd77217c133c: chore(deps): update dependency gotestyourself/gotestsum to v1.12.0 (#21900) (@renovate[bot])&#xD;&#xA;* cae840bb13f1bbb422df6421ec7d3ea55a3902c6: chore(deps): update dependency gotestyourself/gotestsum to v1.12.1 (#22328) (@renovate[bot])&#xD;&#xA;* cf89ee6279b5c95ade65245e81328260dfc37580: chore(deps): update dependency jinja2 to v3.1.5 (#21289) (@renovate[bot])&#xD;&#xA;* 10293889b7e0c1beaf8ab62b1fdf49a1c3082ced: chore(deps): update dependency pygments to v2.19.0 (#21379) (@renovate[bot])&#xD;&#xA;* 9cc52247c429e686039ca6a1f48560ce90f786fc: chore(deps): update dependency pygments to v2.19.1 (#21392) (@renovate[bot])&#xD;&#xA;* a4158226149bdec3f3df7b4e2499782978a8c5a9: chore(deps): update dependency pymdown-extensions to v10.13 (#21301) (@renovate[bot])&#xD;&#xA;* 4fee6b51e071b0a33da262b6d86327db4709dc01: chore(deps): update dependency pymdown-extensions to v10.14 (#21403) (@renovate[bot])&#xD;&#xA;* 42fa72d4999973290defdbf2bf69c0148e0a8d3c: chore(deps): update dependency pymdown-extensions to v10.14.3 (#21619) (@renovate[bot])&#xD;&#xA;* 065fc31a92eecd35c9b1ee8a1bb9751d6374f58e: chore(deps): update module github.com/golangci/golangci-lint to v1.63.2 (#21343) (@renovate[bot])&#xD;&#xA;* 33f2a6fea169bc0fabbf6d2474377928bb763c37: chore(deps): update module github.com/golangci/golangci-lint to v1.63.3 (#21348) (@renovate[bot])&#xD;&#xA;* 8245cd90b35ebd179f592d06d34570cb767c2176: chore(deps): update module github.com/golangci/golangci-lint to v1.63.4 (#21368) (@renovate[bot])&#xD;&#xA;* 2e1db11ad930c505cc8bfcf3c6d0256c6fc204ff: chore(deps): update module github.com/golangci/golangci-lint to v1.64.5 (#21850) (@renovate[bot])&#xD;&#xA;* 95a43e0416907437e8340fe8ce1a47c9bc03bc19: chore(deps): update module github.com/golangci/golangci-lint to v1.64.6 (#22115) (@renovate[bot])&#xD;&#xA;* 12928cbdcc0c03f7da4e556e75478947bf6de573: chore(deps): update module github.com/golangci/golangci-lint to v1.64.7 (#22306) (@renovate[bot])&#xD;&#xA;* d84ac3a6b264e66647fbdc029d39bd157b4f609d: chore(deps-dev): bump @types/mocha from 10.0.9 to 10.0.10 in /ui-test (#21251) (@dependabot[bot])&#xD;&#xA;* 1f1c33983b53ab647586b304c4603f204f1244ed: chore(deps-dev): bump @types/node from 22.10.10 to 22.13.4 in /ui-test (#21874) (@dependabot[bot])&#xD;&#xA;* 41dec01c7c7a993e6287128f4cbc928a52c8c48a: chore(deps-dev): bump @types/node from 22.10.2 to 22.10.5 in /ui-test (#21381) (@dependabot[bot])&#xD;&#xA;* 2f579404f68ded0b0156fc25d6e554640c4ad009: chore(deps-dev): bump @types/node from 22.10.5 to 22.10.6 in /ui-test (#21482) (@dependabot[bot])&#xD;&#xA;* 3a29a745a38ab2e123eb0137d9285cb203737479: chore(deps-dev): bump @types/node from 22.10.6 to 22.10.7 in /ui-test (#21511) (@dependabot[bot])&#xD;&#xA;* 770664411aa232ae537227aed15250fdc876343f: chore(deps-dev): bump @types/node from 22.10.7 to 22.10.8 in /ui-test (#21644) (@dependabot[bot])&#xD;&#xA;* 75def4f2df3e27892292b8020bfb9100a2784105: chore(deps-dev): bump @types/node from 22.10.8 to 22.10.10 in /ui-test (#21658) (@dependabot[bot])&#xD;&#xA;* 33ad0a7ba717cec4bdfbe205f5ab2d43dba25900: chore(deps-dev): bump @types/node from 22.13.4 to 22.13.5 in /ui-test (#21960) (@dependabot[bot])&#xD;&#xA;* 111cf2ce9fef0a2b355e11b51af75ed0f87e9330: chore(deps-dev): bump @types/node from 22.13.5 to 22.13.10 in /ui-test (#22272) (@dependabot[bot])&#xD;&#xA;* 235470fb2611d327eed2f78483ec46e56c49b4c1: chore(deps-dev): bump @types/node from 22.9.3 to 22.10.2 in /ui-test (#21143) (@dependabot[bot])&#xD;&#xA;* 5b482d738a90b62b65ef503557244f5552997397: chore(deps-dev): bump mocha from 10.7.3 to 11.0.1 in /ui-test (#21030) (@dependabot[bot])&#xD;&#xA;* b77d9d9f5f9cf3862ef75e14a5877a3fcf60fa40: chore(deps-dev): bump typescript from 5.7.2 to 5.7.3 in /ui-test (#21443) (@dependabot[bot])&#xD;&#xA;* 05a9171b4236c8db96a95d895c6dc1542c051719: chore(deps-dev): bump typescript from 5.7.3 to 5.8.2 in /ui-test (#22118) (@dependabot[bot])&#xD;&#xA;### Other work&#xD;&#xA;* fdf21f7763f2f301e244885d0df39d35f87034cd: Add pollinate to USERS.md (#21247) (@shavmohin)&#xD;&#xA;* 3f0a1552e6b01e9ce36cf874d8392c64b7a0d281: Fix application url for custom base href (#21377) (@amit-o)&#xD;&#xA;* c6893527a76749b4f64862b33981572188cc5f0b: Fixing the link in the docs (#21316) (@ali-hamza-noor)&#xD;&#xA;* 6f5537bdf15ddbaa0f27a1a678632ff0743e4107: Merge commit from fork (@svghadi)&#xD;&#xA;* 4d59154a8817e0db3ecbc491cce45b1d9cb8b0c5: Replace deprecated go-gitlab dependency with client-go. (#21175) (@gbw)&#xD;&#xA;* 9309688a8aeb06877e59c0de416f95562813da4d: Stabilize on-deployed notification trigger (#21333) (@svghadi)&#xD;&#xA;* cce4a284be69d0840feb999069f1c0e6f6b8ab3d: Update ingress.md (#21324) (@aliabbasjaffri)&#xD;&#xA;* 80edbfed80d9bffb7348db8ce493424274df900a: Update toolchain-guide.md (#21288) (@Jonty16117)&#xD;&#xA;* 0b542baacb31ec62142277a8cec4ef5b316650cf: add `project` missing field to spec (#21277) (@afzal442)&#xD;&#xA;* 1194766ebaa8279442288e9a3f049b38dbcf5048: added-ACL (#21238) (@surajyadav1108)&#xD;&#xA;* fe598a831e42a2838242f99d6a74be520f27908a: chore!: add 60s default jitter (#22342) (@agaudreault)&#xD;&#xA;* 47bec8b43808af1ffd07dac6d686503a869a7869: chore!: remove legacy repo support (#19768) (#21249) (@crenshaw-dev)&#xD;&#xA;* 5d147a3ae665053ed4ec6f77c994540abf9ce40e: chore(appset)!: always apply nested selectors (#14152) (#21492) (@crenshaw-dev)&#xD;&#xA;* 928fd19593823aff01da189baee0aa662ab05624: chore(appset): simplify cluster list code (#21820) (@crenshaw-dev)&#xD;&#xA;* 75bbb50db3a7d31daf815feeb29b498308c773a6: chore(appset): use DB instead of kube client for cluster validation (#21190) (@crenshaw-dev)&#xD;&#xA;* 226a670fe6b3c6769ff6d18e6839298a58e4577d: chore(ci): improve previous-version script readability, fix bug (cherry-pick #22378) (#22381) (@gcp-cherry-pick-bot[bot])&#xD;&#xA;* 77ad48aa09c301b41fdbaee5908a5b18b3f93a26: chore(ci): run codegen as part of version bump job (#21404) (@crenshaw-dev)&#xD;&#xA;* 335b65baf88c4c7155f851bb3450f72d4800a355: chore(config)!: Ignore all `.status` updates &amp; known high churn changes by default (#21760) (@agaudreault)&#xD;&#xA;* ab07b0aed57d46bd52e0544b210b7be5ce5db66e: chore(controller): simplify sharding code (#21244) (@crenshaw-dev)&#xD;&#xA;* 261137df9de628b3519ba638e3a8facc5ee0d327: chore(health): report progressing status for AppSets (#22092) (@crenshaw-dev)&#xD;&#xA;* be293fe9ed300a150357b3df60837ad8517d2a6e: chore(hydrator): improve error message (#21987) (@crenshaw-dev)&#xD;&#xA;* 42219fd7b7b865eb4e0f2343d6f53d613a2fbd95: chore(lint): fix deep copy informers lint (#22290) (@crenshaw-dev)&#xD;&#xA;* 4e08b8dee6ce10bbaceed4fdfbc2704f35e73cc8: chore(metrics)!: remove deprecated metrics (#21697) (@crenshaw-dev)&#xD;&#xA;* bd3745889616ed00d9ba1e7e4e2059ab906935d5: chore(refactor): remove app destination inferrence logic (#21189) (@crenshaw-dev)&#xD;&#xA;* 34fd7296b1d403246b8ca957edab8f45e63e7b48: chore(refactor): remove unused function/file (#21245) (@crenshaw-dev)&#xD;&#xA;* bd9923fd75439821639abe2697e3d99ed723c29b: chore(repo-server): simplify Kustomize/Helm version detection (#21540) (@crenshaw-dev)&#xD;&#xA;* 566bc2e5e8f6b458fbfb64b6a908f8b275f4f5d3: chore(test): simplify test assertions (#21242) (@crenshaw-dev)&#xD;&#xA;* ecd0bcdd589f594b91a11abac548cb810665e84e: chore(ui): resolve `ts-jest` config under `globals` is deprecated (#20036) (@jsoref)&#xD;&#xA;* b6770bdb7985b30a8badec5fda3ff4fde542d0cc: chore: Add divar.ir to USERS.md (#21344) (@aminarefzadeh)&#xD;&#xA;* 12a4dabd1c2011fa570e57223195adb6ea130145: chore: Fix data race detection failures in application tests (#21271) (@eadred)&#xD;&#xA;* 45e488657bf3d9dd1dc249b0485634a5c500e7b8: chore: Graceful shutdown for API Server (#18642) (#21224) (@andrii-korotkov-verkada)&#xD;&#xA;* 2ce593b5de337a9a40ab0a53e7fac31577d7d031: chore: Optimize Docker image layers (#21525) (@marcofranssen)&#xD;&#xA;* 07da3d41da22b0d16defa9bfcf9f1ac2428aa4ed: chore: Option to disable sync with replace on API Server level (#21427) (#22073) (@andrii-korotkov-verkada)&#xD;&#xA;* 9d66e89d14fcdbd761ddd02b60a69f5cf11179a5: chore: Remove k8s 1.28 from e2e testing (#22245) (@andrii-korotkov-verkada)&#xD;&#xA;* e14d6b7bf9dc4800307576fbec1351548e5d43b9: chore: Update notifications to be less spammy (#20871) (#21884) (@andrii-korotkov-verkada)&#xD;&#xA;* 8d1aeb58a2aa61bc13bffb797b857cf750bc5f62: chore: Update some dependencies and add some comments about old libs (#22104) (#22208) (@andrii-korotkov-verkada)&#xD;&#xA;* 5223ce546a677565a24dc37d53a360d544891ba1: chore: Upgrade Redis from 7.0.15-alpine to 7.2.7-alpine and haproxy (#22108) (#22110) (@andrii-korotkov-verkada)&#xD;&#xA;* d765aabc1ff29a1524dc06164403b117d1c2f2d7: chore: Upgrade ubuntu base image to latest 24.04 digest (#21524) (@marcofranssen)&#xD;&#xA;* 91cb69316479fbe7144e66291d38c8c00996bca3: chore: action docker warnings (#21556) (@Softyy)&#xD;&#xA;* 8a447d9ae01f0c4358bc0d7553c120c43a8b99e5: chore: add e2e test for hook finalizer which prevents external resource deletion (#21113) (@dejanzele)&#xD;&#xA;* 6daaac59249d76e16a63fc6e047ded67d39222cf: chore: add log context to proxy extension requests (#21834) (@leoluz)&#xD;&#xA;* acb47b418ca3270ad4b24a754fd3292988aaa5b1: chore: add script to bump major version (#21363) (@crenshaw-dev)&#xD;&#xA;* 944f9f7b68b92e78a249a99f19dba001837461c6: chore: add the Argo CD type definitions and method comments  (#21854) (@nitishfy)&#xD;&#xA;* f044200d9e1d548002422d0a9d109ba95381f52a: chore: bump gitops-engine (#22335) (@pjiang-dev)&#xD;&#xA;* 76dbaaa3e0a315892623fadb3e9f867d9665dfb4: chore: bump to github.com/grpc-ecosystem/go-grpc-middleware/v2 (#22098) (@mmorel-35)&#xD;&#xA;* 9b91454968eafed8b2a8e181b036270d27779117: chore: cleanup `diff-cache` testdata (#21600) (@llavaud)&#xD;&#xA;* 8507a87bfa7b7a66351d0b0972f99624ec3d01c9: chore: define apiextensionsv1 alias with importas (#21823) (@mmorel-35)&#xD;&#xA;* 74582e9965c09f17f2d5dd6629a2a03c50548d2f: chore: embed trivial rand string function (#22177) (@crenshaw-dev)&#xD;&#xA;* 35a174b95631887760c4347975a0c0c6092bf900: chore: enable badCond from gocritic (#21632) (@mmorel-35)&#xD;&#xA;* b04a7c101dfa4512e12145d5241685ab337d6532: chore: enable context-as-argument from revive (#21371) (@mmorel-35)&#xD;&#xA;* c80325737efd30acca2ccbcd5cd68d6134ad38ca: chore: enable duplicated-imports from revive (#21378) (@mmorel-35)&#xD;&#xA;* 6c457217305a2e5f3f431b406a18cdc1b5d4503a: chore: enable early-return from revive (#21423) (@mmorel-35)&#xD;&#xA;* f245e8beb52e2dd08860f9222a33a2c215b7f291: chore: enable err-error and strconcat of perfsprint linter (#21267) (@mmorel-35)&#xD;&#xA;* 8a6f53d04412a0cef0233eeee7c2df68b6be8495: chore: enable errorf of perfsprint linter (#21280) (@mmorel-35)&#xD;&#xA;* bf082c26c272e1f1a1e91e36110551d86204d11d: chore: enable ifElseChain from gocritic (#21636) (@mmorel-35)&#xD;&#xA;* 5508d1fedaf56be03d74f8d5bed8cd82eb46e10f: chore: enable importas for k8s.io/apimachinery/pkg/api/errors (#21262) (@mmorel-35)&#xD;&#xA;* 812650847cfe349c6700060db37e8da615637d3a: chore: enable importas for k8s.io/apimachinery/pkg/apis/meta/v1 (#21284) (@mmorel-35)&#xD;&#xA;* 4e5db16fbfce29ba0c20a58ac99294658339e975: chore: enable increment-decrement from revive (#21366) (@mmorel-35)&#xD;&#xA;* 947a7b84d7b5096fd986cff3a60c0bc5905ffa4b: chore: enable indent-error-flow from revive (#21394) (@mmorel-35)&#xD;&#xA;* 5ef4faa8a4ba5486ffde9cffc4ec4f60eedec1ec: chore: enable nolintlint (#21559) (@mmorel-35)&#xD;&#xA;* 753f7b6e7297b65698a9fbd4e33dcdceda031ecf: chore: enable parallel helm manifest generation by default (#22224) (@nitishfy)&#xD;&#xA;* c739478b8bb6e2657ffec762e72f1cea4dca7871: chore: enable receiver-naming from revive (#21372) (@mmorel-35)&#xD;&#xA;* 9f0dc9402fb8245d95834b29f19397ff758147db: chore: enable redundant-import-alias from revive (#21386) (@mmorel-35)&#xD;&#xA;* 24893ad5e9c0b2d9c2f49fa5a4bc958f55fd8833: chore: enable several rules from revive (#21638) (@mmorel-35)&#xD;&#xA;* 27915da5b06f526bc0045302f34b65fff7ed0738: chore: enable singleCaseSwitch and commentFormatting rules from gocritic (#21616) (@mmorel-35)&#xD;&#xA;* cb3024c5ff33fdc393028ff27ebda021fb0de488: chore: enable superfluous-else from revive (#21373) (@mmorel-35)&#xD;&#xA;* 50c49ec8f91997970e1b22b605f94153d51fe622: chore: enable unnecessary-stmt from revive (#21398) (@mmorel-35)&#xD;&#xA;* 53bc19b5f20d56613c57c664f462ad2a484d9424: chore: enable unused-parameter from revive (#21365) (@mmorel-35)&#xD;&#xA;* 9ea979bbcdc76223890388c4b83ced88505b95ce: chore: enable use-any from revive (#21282) (@mmorel-35)&#xD;&#xA;* 37aaeb3dd9fc63f701a96307369f53a9a0c4af12: chore: enable usetesting linter (#21935) (@mmorel-35)&#xD;&#xA;* e66068c11b5a00be03bc9b012801635202ed30ad: chore: enable var-declaration from revive (#21370) (@mmorel-35)&#xD;&#xA;* c1b2f78f4609d2dbf8691a9fb333fa45d3808812: chore: enable var-naming from revive (#21861) (@mmorel-35)&#xD;&#xA;* ceb758c8772ae70d73246fe224e5b9fd6484a0ac: chore: import k8s.io/api/core/v1 as corev1 (#21345) (@mmorel-35)&#xD;&#xA;* 3593f2449179035cf3dd181ecf691658e89376a2: chore: mark with-hydrator manifests as generated (#21639) (@crenshaw-dev)&#xD;&#xA;* 045a0277530c892091069205a49135d6f1e507f8: chore: reggie-k as release champion for 3.0 (#21736) (@reggie-k)&#xD;&#xA;* ffdbcb6f3113c62841d9a6e6d3902efcc9815db9: chore: reuse common PermissionDeniedAPIError (#21283) (@mmorel-35)&#xD;&#xA;* 2b1220c6007b0d23f5b11f3e9c3d2d5227037563: chore: revise wrong resource customization usage example (#22074) (@hanxiaop)&#xD;&#xA;* aeb00028776d5d85508c42c0ee9bc2dd27731f0d: chore: set default tracking to annotation (#22289) (@crenshaw-dev)&#xD;&#xA;* 9b17495bc2fe7c6f07ed5ac5cc154b3ae9027be9: chore: update go-github to use token (#21292) (@aburan28)&#xD;&#xA;* 38c2b34da0c0fe6984a733b36944e9651ce7e710: chore: update gotestsum automatically (#21828) (@mikutas)&#xD;&#xA;* 228b86d3b5ab83c9727426291b037e173b88c211: chore: update mockery version (#22126) (@gdsoumya)&#xD;&#xA;* e3bcc48bf2dc92c1f397dc28a333881106a8a653: chore: updates to Numaplane health checks (#21671) (@juliev0)&#xD;&#xA;* 922d080ae516ef77ca6a74a0b2a90a5c5de15c7f: chore: upgrade Go to 1.24 (#22242) (@sivchari)&#xD;&#xA;* ef55ba549bd7893d80223c19a16fb1d1368d3f0c: chore: use dario.cat/mergo instead of github.com/imdario/mergo (#21274) (@mmorel-35)&#xD;&#xA;* 6087b4f903f0d862618bb43e8496c86c6ea1494d: chore: use github.com/golang-jwt/jwt/v5 (#21276) (@mmorel-35)&#xD;&#xA;* 795bda5dd853a82f4d0234856b0d9dc809f9d303: chore: use github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus (#21937) (@mmorel-35)&#xD;&#xA;* 83257a9e73ce6357e3903f1d585495b7b5532eba: chore: use grpc-middleware interceptors (#22329) (@mmorel-35)&#xD;&#xA;* db82e23ebb291bf9f2bcf4539310fe895c585ab7: chore: use internal errors util instead of pkg&#39;s (#22174) (@crenshaw-dev)&#xD;&#xA;* 48334cfcd5812e3291c1bb51768a2317e7df00b3: chore: use standard errors instead of github.com/pkg/errors (#21266) (@mmorel-35)&#xD;&#xA;* 9843bfbdf811a5f959441ec06a47a9ac49e23e7c: chore: use testify instead of native testing (#21781) (@mmorel-35)&#xD;&#xA;* 13235ad477e82723bc749f4410cf38cec3dda55b: chore: use testify instead of testing.Fatal (#21258) (@mmorel-35)&#xD;&#xA;* d7ccf4705719dc0de5d56337a78ba26e0a348df2: chore: use testify instead of testing.Fatal or testing.Error in pkg (#20761) (@mmorel-35)&#xD;&#xA;* e7d909164c161e399391f5c0ac4d1c22600a8cf4: chore: use testify instead of testing.Fatal or testing.Error in reposerver (#20762) (@mmorel-35)&#xD;&#xA;* 644af54a7c61b07021125682f4526dd9c6853974: chore: version bumping helm3 (#22009) (@igaskin)&#xD;&#xA;* e147247aaf49f64b9017e2a7d5b512c4482a4725: ci: disable nolintlint linter (#21707) (@agaudreault)&#xD;&#xA;* 976a8498d48b9475d3899455f6d1b867980aa7bc: ci: fixes #21862 Concurrency in pr-title-check (#21863) (@appiepollo14)&#xD;&#xA;* e5df9991837d7f27ae06a71e3bba9c997e691a0f: crepocreds-short-changed (#21285) (@surajyadav1108)&#xD;&#xA;* 9a3cfcb71d1e1e2fb1420b5b23d8bdca2374a36e: docs(2.14): adding basic upgrading docs for 2.14 (#21744) (@rumstead)&#xD;&#xA;* 622847bcb5f7fbc1228403dd83d9f4ec818cecf3: docs(2.14): use 2.14.1 manifests as remote bases (#21759) (@rumstead)&#xD;&#xA;* 073ccf7c35a63bb203b8c78dec3e8a7c2efecdeb: fix(#19314, #15700): allow `ssh`/`altssh` subdomains in repo URLs to match webhook payload (#21227) (@mtbennett-godaddy)&#xD;&#xA;* 8f285a5dd40308b083523a3fd0aeac03b6f134dc: fix(in-cluster): do not allow the cluster to be used when disabled (#21208) (@agaudreault)&#xD;&#xA;* a1431bef4c3aea396956c53e593078414f0f478e: fix(ui, rbac): project-roles (#21829) (@blakepettersson)&#xD;&#xA;* 26ebb9bb5e07ac095002d06638847b808cff6c7c: fixed the broken link while version upgrade/degrade (#21279) (@afzal442)&#xD;&#xA;* 2bcaa1989418c7b544a003af21789cdf52492883: revert: add a check for user defined role referential integrity  #21065 (#22130) (@rumstead)&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/argoproj/argo-cd/compare/v2.14.11...v3.0.0&#xD;&#xA;&#xD;&#xA;&lt;a href=&#34;https://argoproj.github.io/cd/&#34;&gt;&lt;img src=&#34;https://raw.githubusercontent.com/argoproj/argo-site/master/content/pages/cd/gitops-cd.png&#34; width=&#34;25%&#34; &gt;&lt;/a&gt;&#xD;&#xA;&#xD;&#xA;</pre>
            </details>
        </details>
        <a href="https://github.com/mprochowski/k3s-cluster-gitops/actions/runs/14864425294">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

