### PR TITLE
k3s-io/k3s: bump version to v1.32.8+k3s1

### DIFF
--- a/.charts/1-infrastructure/system-upgrade-controller/values.yaml
+++ b/.charts/1-infrastructure/system-upgrade-controller/values.yaml
@@ -1,2 +1,2 @@
 kubernetes:
-  version: v1.32.4+k3s1
+  version: v1.32.8+k3s1

--- a/1-infrastructure/system-upgrade-controller/plans.yaml
+++ b/1-infrastructure/system-upgrade-controller/plans.yaml
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.32.4+k3s1
+  version: v1.32.8+k3s1
 ---
 # Source: system-upgrade-controller/templates/plans.yaml
 # Agent plan
@@ -42,4 +42,4 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.32.4+k3s1
+  version: v1.32.8+k3s1


### PR DESCRIPTION



<Actions>
    <action id="32378aa2665b229d8619fccc2da26de763ac7ea67bcad573ba096abdf76f9240">
        <h3>k3s-io/k3s</h3>
        <details id="37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f">
            <summary>k3s-io/k3s: bump version to v1.32.8+k3s1</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.kubernetes.version&#34; updated from &#34;v1.32.4+k3s1&#34; to &#34;v1.32.8+k3s1&#34;, in file &#34;.charts/1-infrastructure/system-upgrade-controller/values.yaml&#34;</p>
            <details>
                <summary>v1.30.13+k3s1</summary>
                <pre>&lt;!-- v1.30.13+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.30.13, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#changelog-since-v13012).&#xD;&#xA;&#xD;&#xA;## Changes since v1.30.12+k3s1:&#xD;&#xA;&#xD;&#xA;* Testing backports for 2025 May [(#12235)](https://github.com/k3s-io/k3s/pull/12235)&#xD;&#xA;* Backports for May [(#12316)](https://github.com/k3s-io/k3s/pull/12316)&#xD;&#xA;* Backports for 2025-05 [(#12333)](https://github.com/k3s-io/k3s/pull/12333)&#xD;&#xA;* Fix authorization-config/authentication-config handling [(#12347)](https://github.com/k3s-io/k3s/pull/12347)&#xD;&#xA;* Fix secretsencrypt race conditions [(#12358)](https://github.com/k3s-io/k3s/pull/12358)&#xD;&#xA;* Update to v1.30.13-k3s1 and Go 1.23.8 [(#12364)](https://github.com/k3s-io/k3s/pull/12364)&#xD;&#xA;* Fix startup e2e test [(#12372)](https://github.com/k3s-io/k3s/pull/12372)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.30.13](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#v13013) |&#xD;&#xA;| Kine | [v0.13.15](https://github.com/k3s-io/kine/releases/tag/v0.13.15) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v1.7.27-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.27-k3s1) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.26.7](https://github.com/flannel-io/flannel/releases/tag/v0.26.7) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v2.11.24](https://github.com/traefik/traefik/releases/tag/v2.11.24) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.10) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
            <details>
                <summary>v1.30.13-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.30.14+k3s1</summary>
                <pre>&lt;!-- v1.30.14+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.30.14, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#changelog-since-v13013).&#xD;&#xA;&#xD;&#xA;## Changes since v1.30.13+k3s1:&#xD;&#xA;&#xD;&#xA;* Backports for 2025-06 [(#12499)](https://github.com/k3s-io/k3s/pull/12499)&#xD;&#xA;* Bump helm-controller [(#12521)](https://github.com/k3s-io/k3s/pull/12521)&#xD;&#xA;* Update network components [(#12516)](https://github.com/k3s-io/k3s/pull/12516)&#xD;&#xA;* Update to v1.30.14-k3s1 and Go 1.23.10 [(#12532)](https://github.com/k3s-io/k3s/pull/12532)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.30.14](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#v13014) |&#xD;&#xA;| Kine | [v0.13.15](https://github.com/k3s-io/kine/releases/tag/v0.13.15) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v1.7.27-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.27-k3s1) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v2.11.24](https://github.com/traefik/traefik/releases/tag/v2.11.24) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.11](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.11) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.30.14+k3s2</summary>
                <pre>&lt;!-- v1.30.14+k3s2 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.30.14, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#changelog-since-v13014).&#xD;&#xA;&#xD;&#xA;## Changes since v1.30.14+k3s1:&#xD;&#xA;&#xD;&#xA;* Add usage description for etcd-snapshot [(#12571)](https://github.com/k3s-io/k3s/pull/12571)&#xD;&#xA;* Build and push k3s image to GHCR [(#12576)](https://github.com/k3s-io/k3s/pull/12576)&#xD;&#xA;* GHA + Testing Backports [(#12611)](https://github.com/k3s-io/k3s/pull/12611)&#xD;&#xA;* Refac for shell completion [(#12633)](https://github.com/k3s-io/k3s/pull/12633)&#xD;&#xA;  * K3s completion shell command will now be separate to specific subcommands for bash and zsh&#xD;&#xA;* Backports for 2025-07 [(#12643)](https://github.com/k3s-io/k3s/pull/12643)&#xD;&#xA;* Update to v1.30.14-k3s2 and Go 1.23.10 [(#12662)](https://github.com/k3s-io/k3s/pull/12662)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.30.14](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#v13014) |&#xD;&#xA;| Kine | [v0.13.17](https://github.com/k3s-io/kine/releases/tag/v0.13.17) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v1.7.27-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.27-k3s1) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v2.11.24](https://github.com/traefik/traefik/releases/tag/v2.11.24) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.30.14-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.30.14-rc1+k3s2</summary>
            </details>
            <details>
                <summary>v1.31.10+k3s1</summary>
                <pre>&lt;!-- v1.31.10+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.31.10, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#changelog-since-v1319).&#xD;&#xA;&#xD;&#xA;## Changes since v1.31.9+k3s1:&#xD;&#xA;&#xD;&#xA;* GHCR image release [(#12461)](https://github.com/k3s-io/k3s/pull/12461)&#xD;&#xA;* Backports for 2025-06 [(#12498)](https://github.com/k3s-io/k3s/pull/12498)&#xD;&#xA;* Bump helm-controller [(#12520)](https://github.com/k3s-io/k3s/pull/12520)&#xD;&#xA;* Update network components [(#12515)](https://github.com/k3s-io/k3s/pull/12515)&#xD;&#xA;* Update to v1.31.10-k3s1 and Go 1.23.10 [(#12531)](https://github.com/k3s-io/k3s/pull/12531)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.31.10](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v13110) |&#xD;&#xA;| Kine | [v0.13.15](https://github.com/k3s-io/kine/releases/tag/v0.13.15) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s1.32](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s1.32) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v2.11.24](https://github.com/traefik/traefik/releases/tag/v2.11.24) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.11](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.11) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.31.10-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.31.11+k3s1</summary>
                <pre>&lt;!-- v1.31.11+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.31.11, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#changelog-since-v13110).&#xD;&#xA;&#xD;&#xA;## Changes since v1.31.10+k3s1:&#xD;&#xA;&#xD;&#xA;* Add usage description for etcd-snapshot [(#12572)](https://github.com/k3s-io/k3s/pull/12572)&#xD;&#xA;* Refac shell completion to a better command structure [(#12604)](https://github.com/k3s-io/k3s/pull/12604)&#xD;&#xA;  * K3s completion shell command will now be separate to specific subcommands for bash and zsh&#xD;&#xA;* GHA + Testing Backports [(#12610)](https://github.com/k3s-io/k3s/pull/12610)&#xD;&#xA;* Backports for 2025-07 [(#12642)](https://github.com/k3s-io/k3s/pull/12642)&#xD;&#xA;* Update to v1.31.11-k3s1 [(#12650)](https://github.com/k3s-io/k3s/pull/12650)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.31.11](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v13111) |&#xD;&#xA;| Kine | [v0.13.17](https://github.com/k3s-io/kine/releases/tag/v0.13.17) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s2.32](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2.32) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v2.11.24](https://github.com/traefik/traefik/releases/tag/v2.11.24) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.31.11-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.31.12+k3s1</summary>
                <pre>&lt;!-- v1.31.12+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.31.12, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#changelog-since-v13111).&#xD;&#xA;&#xD;&#xA;## Changes since v1.31.11+k3s1:&#xD;&#xA;&#xD;&#xA;* Add retention flag specific for s3 [(#12696)](https://github.com/k3s-io/k3s/pull/12696)&#xD;&#xA;* Backport For August [(#12721)](https://github.com/k3s-io/k3s/pull/12721)&#xD;&#xA;* Bump coredns to 1.12.3 [(#12732)](https://github.com/k3s-io/k3s/pull/12732)&#xD;&#xA;* - Bump metrics-server to v0.8.0 [(#12743)](https://github.com/k3s-io/k3s/pull/12743)&#xD;&#xA;* Fix cert startup check events [(#12748)](https://github.com/k3s-io/k3s/pull/12748)&#xD;&#xA;* Emit certs OK event on startup, if no certs need renewal [(#12762)](https://github.com/k3s-io/k3s/pull/12762)&#xD;&#xA;* Update metric help to be more descriptive. [(#12766)](https://github.com/k3s-io/k3s/pull/12766)&#xD;&#xA;* Update to v1.31.12-k3s1 and Go 1.23.11 [(#12763)](https://github.com/k3s-io/k3s/pull/12763)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.31.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v13112) |&#xD;&#xA;| Kine | [v0.13.17](https://github.com/k3s-io/kine/releases/tag/v0.13.17) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s2.32](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2.32) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) |&#xD;&#xA;| Traefik | [v2.11.24](https://github.com/traefik/traefik/releases/tag/v2.11.24) |&#xD;&#xA;| CoreDNS | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | &#xD;&#xA;| Helm-controller | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.31.12-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.31.9+k3s1</summary>
                <pre>&lt;!-- v1.31.9+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.31.9, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#changelog-since-v1318).&#xD;&#xA;&#xD;&#xA;## Changes since v1.31.8+k3s1:&#xD;&#xA;&#xD;&#xA;* Testing backports for 2025 May [(#12234)](https://github.com/k3s-io/k3s/pull/12234)&#xD;&#xA;* Backports for May [(#12317)](https://github.com/k3s-io/k3s/pull/12317)&#xD;&#xA;* Backports for 2025-05 [(#12328)](https://github.com/k3s-io/k3s/pull/12328)&#xD;&#xA;* Fix authorization-config/authentication-config handling [(#12346)](https://github.com/k3s-io/k3s/pull/12346)&#xD;&#xA;* Fix secretsencrypt race conditions [(#12357)](https://github.com/k3s-io/k3s/pull/12357)&#xD;&#xA;* Update to v1.31.9-k3s1 and Go 1.23.8 [(#12363)](https://github.com/k3s-io/k3s/pull/12363)&#xD;&#xA;* Fix startup e2e test [(#12371)](https://github.com/k3s-io/k3s/pull/12371)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.31.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1319) |&#xD;&#xA;| Kine | [v0.13.15](https://github.com/k3s-io/kine/releases/tag/v0.13.15) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s1.32](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s1.32) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.26.7](https://github.com/flannel-io/flannel/releases/tag/v0.26.7) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v2.11.24](https://github.com/traefik/traefik/releases/tag/v2.11.24) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.10) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
            <details>
                <summary>v1.31.9-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.32.4+k3s1</summary>
                <pre>&lt;!-- v1.32.4+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.32.4, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1323).&#xD;&#xA;&#xD;&#xA;## Changes since v1.32.3+k3s1:&#xD;&#xA;&#xD;&#xA;* Migrate to UrfaveCLI v2 [(#12031)](https://github.com/k3s-io/k3s/pull/12031)&#xD;&#xA;* Improve readiness polling on node startup [(#12038)](https://github.com/k3s-io/k3s/pull/12038)&#xD;&#xA;* Fix issue caused by default authorization-mode apiserver arg [(#12042)](https://github.com/k3s-io/k3s/pull/12042)&#xD;&#xA;* Fix flakey etcd startup tests [(#12050)](https://github.com/k3s-io/k3s/pull/12050)&#xD;&#xA;* Cleanup anonymous and named volumes for docker tests [(#12079)](https://github.com/k3s-io/k3s/pull/12079)&#xD;&#xA;* Add support for secretbox encryption provider with the `k3s secrets-encrypt` command [(#12067)](https://github.com/k3s-io/k3s/pull/12067)&#xD;&#xA;  * Users can now configure secrets encryption to use `secretbox` provider by setting the `secrets-encryption-provider` flag.&#xD;&#xA;* Add error in certificate check [(#12098)](https://github.com/k3s-io/k3s/pull/12098)&#xD;&#xA;* Backports for 2025-04 [(#12104)](https://github.com/k3s-io/k3s/pull/12104)&#xD;&#xA;* Bump kine for nats-server/v2 CVE-2025-30215 [(#12141)](https://github.com/k3s-io/k3s/pull/12141)&#xD;&#xA;* Drone Test Split and Reduction [(#12151)](https://github.com/k3s-io/k3s/pull/12151)&#xD;&#xA;* More backports for 2025-04 [(#12167)](https://github.com/k3s-io/k3s/pull/12167)&#xD;&#xA;* Fix handler panic when bootstrapper returns empty peer list [(#12178)](https://github.com/k3s-io/k3s/pull/12178)&#xD;&#xA;* Bump traefik to v3.3.6 [(#12189)](https://github.com/k3s-io/k3s/pull/12189)&#xD;&#xA;* Update to v1.32.4-k3s1 and Go 1.23.6 [(#12209)](https://github.com/k3s-io/k3s/pull/12209)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.32.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1324) |&#xD;&#xA;| Kine | [v0.13.14](https://github.com/k3s-io/kine/releases/tag/v0.13.14) |&#xD;&#xA;| SQLite | [3.46.1](https://sqlite.org/releaselog/3_46_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.4-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.4-k3s2) |&#xD;&#xA;| Runc | [v1.2.5](https://github.com/opencontainers/runc/releases/tag/v1.2.5) |&#xD;&#xA;| Flannel | [v0.26.7](https://github.com/flannel-io/flannel/releases/tag/v0.26.7) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.10) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
            <details>
                <summary>v1.32.5+k3s1</summary>
                <pre>&lt;!-- v1.32.5+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.32.5, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1324).&#xD;&#xA;&#xD;&#xA;## Changes since v1.32.4+k3s1:&#xD;&#xA;&#xD;&#xA;* Testing backports for 2025 May [(#12233)](https://github.com/k3s-io/k3s/pull/12233)&#xD;&#xA;* Backports for May [(#12318)](https://github.com/k3s-io/k3s/pull/12318)&#xD;&#xA;* Backports for 2025-05 [(#12327)](https://github.com/k3s-io/k3s/pull/12327)&#xD;&#xA;* Fix authorization-config/authentication-config handling [(#12345)](https://github.com/k3s-io/k3s/pull/12345)&#xD;&#xA;* Fix secretsencrypt race conditions [(#12356)](https://github.com/k3s-io/k3s/pull/12356)&#xD;&#xA;* Fix startup e2e test [(#12359)](https://github.com/k3s-io/k3s/pull/12359)&#xD;&#xA;* Update to v1.32.5-k3s1 and Go 1.23.8 [(#12361)](https://github.com/k3s-io/k3s/pull/12361)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.32.5](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1325) |&#xD;&#xA;| Kine | [v0.13.15](https://github.com/k3s-io/kine/releases/tag/v0.13.15) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s1.32](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s1.32) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.26.7](https://github.com/flannel-io/flannel/releases/tag/v0.26.7) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.10) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
            <details>
                <summary>v1.32.5-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.32.6+k3s1</summary>
                <pre>&lt;!-- v1.32.6+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.32.6, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1325).&#xD;&#xA;&#xD;&#xA;## Changes since v1.32.5+k3s1:&#xD;&#xA;&#xD;&#xA;* GHCR image release [(#12463)](https://github.com/k3s-io/k3s/pull/12463)&#xD;&#xA;* Backports for 2025-06 [(#12497)](https://github.com/k3s-io/k3s/pull/12497)&#xD;&#xA;* Bump helm-controller [(#12519)](https://github.com/k3s-io/k3s/pull/12519)&#xD;&#xA;* Update network components [(#12513)](https://github.com/k3s-io/k3s/pull/12513)&#xD;&#xA;* Update to v1.32.6-k3s1 and Go 1.23.10 [(#12530)](https://github.com/k3s-io/k3s/pull/12530)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.32.6](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1326) |&#xD;&#xA;| Kine | [v0.13.15](https://github.com/k3s-io/kine/releases/tag/v0.13.15) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s1.32](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s1.32) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.11](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.11) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.32.6-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.32.7+k3s1</summary>
                <pre>&lt;!-- v1.32.7+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.32.7, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1326).&#xD;&#xA;&#xD;&#xA;## Changes since v1.32.6+k3s1:&#xD;&#xA;&#xD;&#xA;* Add usage description for etcd-snapshot [(#12574)](https://github.com/k3s-io/k3s/pull/12574)&#xD;&#xA;* Refac shell completion to a better command structure [(#12603)](https://github.com/k3s-io/k3s/pull/12603)&#xD;&#xA;  * K3s completion shell command will now be separate to specific subcommands for bash and zsh&#xD;&#xA;* GHA + Testing Backports [(#12609)](https://github.com/k3s-io/k3s/pull/12609)&#xD;&#xA;* Backports for 2025-07 [(#12641)](https://github.com/k3s-io/k3s/pull/12641)&#xD;&#xA;* Update to v1.32.7-k3s1 [(#12651)](https://github.com/k3s-io/k3s/pull/12651)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.32.7](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1327) |&#xD;&#xA;| Kine | [v0.13.17](https://github.com/k3s-io/kine/releases/tag/v0.13.17) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s2.32](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2.32) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.32.7-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.32.8+k3s1</summary>
                <pre>&lt;!-- v1.32.8+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.32.8, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1327).&#xD;&#xA;&#xD;&#xA;## Changes since v1.32.7+k3s1:&#xD;&#xA;&#xD;&#xA;* Add retention flag specific for s3 [(#12695)](https://github.com/k3s-io/k3s/pull/12695)&#xD;&#xA;* Backports for August [(#12719)](https://github.com/k3s-io/k3s/pull/12719)&#xD;&#xA;* Bump coredns to 1.12.3 [(#12730)](https://github.com/k3s-io/k3s/pull/12730)&#xD;&#xA;* - Bump metrics-server to v0.8.0 [(#12742)](https://github.com/k3s-io/k3s/pull/12742)&#xD;&#xA;* Fix cert startup check events [(#12747)](https://github.com/k3s-io/k3s/pull/12747)&#xD;&#xA;* Emit certs OK event on startup, if no certs need renewal [(#12761)](https://github.com/k3s-io/k3s/pull/12761)&#xD;&#xA;* Update metric help to be more descriptive. [(#12765)](https://github.com/k3s-io/k3s/pull/12765)&#xD;&#xA;* Update to v1.32.8-k3s1 and Go 1.23.11 [(#12759)](https://github.com/k3s-io/k3s/pull/12759)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.32.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1328) |&#xD;&#xA;| Kine | [v0.13.17](https://github.com/k3s-io/kine/releases/tag/v0.13.17) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s2.32](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2.32) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | &#xD;&#xA;| Helm-controller | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.32.8-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.33.0+k3s1</summary>
                <pre>&lt;!-- v1.33.0+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.33.0, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#changelog-since-v1324).&#xD;&#xA;&#xD;&#xA;## Changes since v1.32.4+k3s1&#xD;&#xA;&#xD;&#xA;* Build k3s overhaul [(#12200)](https://github.com/k3s-io/k3s/pull/12200)&#xD;&#xA;* Fix sonobuoy conformance testing [(#12214)](https://github.com/k3s-io/k3s/pull/12214)&#xD;&#xA;* Update k8s version to 1.33 [(#12221)](https://github.com/k3s-io/k3s/pull/12221)&#xD;&#xA;* Remove ghcr from drone [(#12229)](https://github.com/k3s-io/k3s/pull/12229)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.33.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1330) |&#xD;&#xA;| Kine | [v0.13.14](https://github.com/k3s-io/kine/releases/tag/v0.13.14) |&#xD;&#xA;| SQLite | [v3.46.1](https://sqlite.org/releaselog/3_46_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.4-k3s4](https://github.com/k3s-io/containerd/releases/tag/v2.0.4-k3s4) |&#xD;&#xA;| Runc | [v1.2.5](https://github.com/opencontainers/runc/releases/tag/v1.2.5) |&#xD;&#xA;| Flannel | [v0.26.7](https://github.com/flannel-io/flannel/releases/tag/v0.26.7) |&#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) |&#xD;&#xA;| Helm-controller | [v0.16.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.10) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;&#xD;&#xA;* [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;* [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;* [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;* [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
            <details>
                <summary>v1.33.0-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.33.0-rc2+k3s1</summary>
            </details>
            <details>
                <summary>v1.33.1+k3s1</summary>
                <pre>&lt;!-- v1.33.1+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.33.1, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#changelog-since-v1330).&#xD;&#xA;&#xD;&#xA;## Changes since v1.33.0+k3s1:&#xD;&#xA;&#xD;&#xA;* Backports for May [(#12319)](https://github.com/k3s-io/k3s/pull/12319)&#xD;&#xA;* Backports for 2025-05 [(#12325)](https://github.com/k3s-io/k3s/pull/12325)&#xD;&#xA;* Fix authorization-config/authentication-config handling [(#12344)](https://github.com/k3s-io/k3s/pull/12344)&#xD;&#xA;* Fix secretsencrypt race conditions [(#12355)](https://github.com/k3s-io/k3s/pull/12355)&#xD;&#xA;* Update to v1.33.1-k3s1 [(#12360)](https://github.com/k3s-io/k3s/pull/12360)&#xD;&#xA;* Fix startup e2e test [(#12370)](https://github.com/k3s-io/k3s/pull/12370)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.33.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1331) |&#xD;&#xA;| Kine | [v0.13.15](https://github.com/k3s-io/kine/releases/tag/v0.13.15) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s1](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s1) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.26.7](https://github.com/flannel-io/flannel/releases/tag/v0.26.7) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.10) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
            <details>
                <summary>v1.33.1-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.33.2+k3s1</summary>
                <pre>&lt;!-- v1.33.2+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.33.2, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#changelog-since-v1331).&#xD;&#xA;&#xD;&#xA;## Changes since v1.33.1+k3s1:&#xD;&#xA;&#xD;&#xA;* GHCR image release [(#12462)](https://github.com/k3s-io/k3s/pull/12462)&#xD;&#xA;* Backports for 2025-06 [(#12492)](https://github.com/k3s-io/k3s/pull/12492)&#xD;&#xA;* Bump helm-controller [(#12518)](https://github.com/k3s-io/k3s/pull/12518)&#xD;&#xA;* Update network components [(#12512)](https://github.com/k3s-io/k3s/pull/12512)&#xD;&#xA;* Update to v1.33.2-k3s1 and Go 1.24.4 [(#12529)](https://github.com/k3s-io/k3s/pull/12529)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.33.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1332) |&#xD;&#xA;| Kine | [v0.13.15](https://github.com/k3s-io/kine/releases/tag/v0.13.15) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s1](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s1) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.11](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.11) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.33.2-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.33.3+k3s1</summary>
                <pre>&lt;!-- v1.33.3+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.33.3, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#changelog-since-v1332).&#xD;&#xA;&#xD;&#xA;## Changes since v1.33.2+k3s1:&#xD;&#xA;&#xD;&#xA;* Add usage description for etcd-snapshot [(#12573)](https://github.com/k3s-io/k3s/pull/12573)&#xD;&#xA;* Refac shell completion to a better command structure [(#12605)](https://github.com/k3s-io/k3s/pull/12605)&#xD;&#xA;  * K3s completion shell command will now be separate to specific subcommands for bash and zsh&#xD;&#xA;* GHA + Testing Backports [(#12608)](https://github.com/k3s-io/k3s/pull/12608)&#xD;&#xA;* Backports for 2025-07 [(#12631)](https://github.com/k3s-io/k3s/pull/12631)&#xD;&#xA;* Update to v1.33.3-k3s1 [(#12652)](https://github.com/k3s-io/k3s/pull/12652)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.33.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1333) |&#xD;&#xA;| Kine | [v0.13.17](https://github.com/k3s-io/kine/releases/tag/v0.13.17) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | &#xD;&#xA;| Helm-controller | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.33.3-rc1+k3s1</summary>
            </details>
        </details>
        <a href="https://github.com/mprochowski/k3s-cluster-gitops/actions/runs/17658489530">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

