### PR TITLE
cert-manager/cert-manager: bump version to 1.18.0

### DIFF
--- a/.charts/2-services/cert-manager/Chart.yaml
+++ b/.charts/2-services/cert-manager/Chart.yaml
@@ -3,4 +3,4 @@ name: cert-manager
 description: Cert-manager.io
 type: application
 version: 1.0.0
-appVersion: 1.17.2
+appVersion: 1.18.0

--- a/2-services/cert-manager/kustomization.yaml
+++ b/2-services/cert-manager/kustomization.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+  - https://github.com/cert-manager/cert-manager/releases/download/v1.18.0/cert-manager.yaml
 
 patches:
   - patch: |-


### PR DESCRIPTION



<Actions>
    <action id="47192c087650391651e2633362e9ab2da7e4eb187c99f7830a5051e5546ce52e">
        <h3>cert-manager/cert-manager</h3>
        <details id="37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f">
            <summary>cert-manager/cert-manager: bump version to 1.18.0</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.appVersion&#34; updated from &#34;1.17.2&#34; to &#34;1.18.0&#34;, in file &#34;.charts/2-services/cert-manager/Chart.yaml&#34;</p>
            <details>
                <summary>v1.18.0</summary>
                <pre>cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.&#xD;&#xA;&#xD;&#xA;cert-manager 1.18 introduces several new features and breaking changes. Highlights include support for ACME certificate profiles, a new default for `Certificate.Spec.PrivateKey.RotationPolicy` now set to `Always` (breaking change), and the default `Certificate.Spec.RevisionHistoryLimit` now set to `1` (potentially breaking). &#xD;&#xA;&#xD;&#xA;&gt; ℹ️ Be sure to review all new features and changes below, and read the [full release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18) carefully before upgrading.&#xD;&#xA;&#xD;&#xA;### Known Issues&#xD;&#xA; * `Error presenting challenge: admission webhook &#34;validate.nginx.ingress.kubernetes.io&#34; denied the request: ingress contains invalid paths: path /.well-known/acme-challenge/&lt;REDACTED&gt; cannot be used with pathType Exact` (#7791)&#xD;&#xA;&#xD;&#xA;Changes since `v1.17.2`:&#xD;&#xA;&#xD;&#xA;### Feature&#xD;&#xA;&#xD;&#xA;- Add config to the Vault issuer to allow the server-name to be specified when validating the certificates the Vault server presents. (#7663, @ThatsMrTalbot)&#xD;&#xA;- Added `app.kubernetes.io/managed-by: cert-manager` label to the created Let&#39;s Encrypt account keys (#7577, @terinjokes)&#xD;&#xA;- Added certificate issuance and expiration time metrics (`certmanager_certificate_not_before_timestamp_seconds`, `certmanager_certificate_not_after_timestamp_seconds`). (#7612, @solidDoWant)&#xD;&#xA;- Added ingress-shim option: `--extra-certificate-annotations`,  which sets a list of annotation keys to be copied from Ingress-like to resulting Certificate object (#7083, @k0da)&#xD;&#xA;- Added the `iss` short name for the cert-manager `Issuer` resource. (#7373, @SgtCoDFish)&#xD;&#xA;- Added the `ciss` short name for the cert-manager `ClusterIssuer` resource (#7373, @SgtCoDFish)&#xD;&#xA;- Adds the `global.rbac.disableHTTPChallengesRole` helm value to disable HTTP-01 ACME challenges. This allows cert-manager to drop its permission to create pods, improving security when HTTP-01 challenges are not required. (#7666, @ali-hamza-noor)&#xD;&#xA;- Allow customizing signature algorithm (#7591, @tareksha)&#xD;&#xA;- Cache the full DNS response and handle TTL expiration in `FindZoneByFqdn` (#7596, @ThatsIvan)&#xD;&#xA;- Cert-manager now uses a local fork of the golang.org/x/crypto/acme package (#7752, @wallrj)&#xD;&#xA;- Add support for [ACME profiles extension](https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/). (#7777, @wallrj)&#xD;&#xA;- Promote the `UseDomainQualifiedFinalizer` feature to GA. (#7735, @jsoref)&#xD;&#xA;- Switched service/servicemon definitions to use port names instead of numbers. (#7727, @jcpunk)&#xD;&#xA;- The default value of `Certificate.Spec.PrivateKey.RotationPolicy` changed from `Never` to `Always`. (#7723, @wallrj)&#xD;&#xA;- Potentially breaking: Set the default revisionHistoryLimit to 1 for the CertificateRequest revisions (#7758, @ali-hamza-noor)&#xD;&#xA;&#xD;&#xA;### Documentation&#xD;&#xA;&#xD;&#xA;- Fix some comments (#7620, @teslaedison)&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- Bump `go-jose` dependency to address `CVE-2025-27144`. (#7606, @SgtCoDFish)&#xD;&#xA;- Bump `golang.org/x/oauth2` to patch `CVE-2025-22868`. (#7638, @NicholasBlaskey)&#xD;&#xA;- Bump `golang.org/x/crypto` to patch `GHSA-hcg3-q754-cr77`. (#7638, @NicholasBlaskey)&#xD;&#xA;- Bump `github.com/golang-jwt/jwt` to patch `GHSA-mh63-6h87-95cp`. (#7638, @NicholasBlaskey)&#xD;&#xA;- Change of the Kubernetes Ingress pathType from `ImplementationSpecific` to `Exact` for a reliable handling of ingress controllers and enhanced security. (#7767, @sspreitzer)&#xD;&#xA;- Fix AWS Route53 error detection for not-found errors during deletion of DNS records. (#7690, @wallrj)&#xD;&#xA;- Fix behavior when running with `--namespace=&lt;namespace&gt;`: limit the scope of cert-manager to a single namespace and disable cluster-scoped controllers. (#7678, @tsaarni)&#xD;&#xA;- Fix handling of certificates with IP addresses in the `commonName` field; IP addresses are no longer added to the DNS `subjectAlternativeName` list and are instead added to the `ipAddresses` field as expected. (#7081, @johnjcool)&#xD;&#xA;- Fix issuing of certificates via DNS01 challenges on Cloudflare after a breaking change to the Cloudflare API (#7549, @LukeCarrier)&#xD;&#xA;- Fixed the `certmanager_certificate_renewal_timestamp_seconds` metric help text indicating that the metric is relative to expiration time, rather than Unix epoch time. (#7609, @solidDoWant)&#xD;&#xA;- Fixing the service account template to incorporate boolean values for the annotations. (#7698, @ali-hamza-noor)&#xD;&#xA;- Quote nodeSelector values in Helm Chart (#7579, @tobiasbp)&#xD;&#xA;- Skip Gateway TLS listeners in `Passthrough` mode. (#6986, @vehagn)&#xD;&#xA;- Upgrade `golang.org/x/net` fixing `CVE-2025-22870`. (#7619, @dependabot[bot])&#xD;&#xA;&#xD;&#xA;### Other (Cleanup or Flake)&#xD;&#xA;&#xD;&#xA;- ACME E2E Tests: Upgraded Pebble to v2.7.0 and modified the ACME tests to match latest Pebble behaviour. (#7771, @wallrj)&#xD;&#xA;- Patch the `third_party/forked/acme` package with support for the ACME profiles extension. (#7776, @wallrj)&#xD;&#xA;- Promote the `AdditionalCertificateOutputFormats` feature to GA, making additional formats always enabled. (#7744, @erikgb)&#xD;&#xA;- Remove deprecated feature gate `ValidateCAA`. Setting this feature gate is now a no-op which does nothing but print a warning log line (#7553, @SgtCoDFish)&#xD;&#xA;- Update kind images to include the Kubernetes 1.33 node image (#7787, @cert-manager-bot)&#xD;&#xA;- Upgrade Go to `v1.24.4` (#7785, @wallrj)&#xD;&#xA;- Use slices.Contains to simplify code (#7753, @cuinix)&#xD;&#xA;&#xD;&#xA;</pre>
            </details>
        </details>
        <a href="https://github.com/mprochowski/k3s-cluster-gitops/actions/runs/15564603617">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

