### PR TITLE
k3s-io/k3s: bump version to v1.32.9+k3s1

### DIFF
--- a/.charts/1-infrastructure/system-upgrade-controller/values.yaml
+++ b/.charts/1-infrastructure/system-upgrade-controller/values.yaml
@@ -1,2 +1,2 @@
 kubernetes:
-  version: v1.32.8+k3s1
+  version: v1.32.9+k3s1

--- a/1-infrastructure/system-upgrade-controller/plans.yaml
+++ b/1-infrastructure/system-upgrade-controller/plans.yaml
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.32.8+k3s1
+  version: v1.32.9+k3s1
 ---
 # Source: system-upgrade-controller/templates/plans.yaml
 # Agent plan
@@ -42,4 +42,4 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.32.8+k3s1
+  version: v1.32.9+k3s1


### PR DESCRIPTION



<Actions>
    <action id="32378aa2665b229d8619fccc2da26de763ac7ea67bcad573ba096abdf76f9240">
        <h3>k3s-io/k3s</h3>
        <details id="37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f">
            <summary>k3s-io/k3s: bump version to v1.32.9+k3s1</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.kubernetes.version&#34; updated from &#34;v1.32.8+k3s1&#34; to &#34;v1.32.9+k3s1&#34;, in file &#34;.charts/1-infrastructure/system-upgrade-controller/values.yaml&#34;</p>
            <details>
                <summary>v1.31.13+k3s1</summary>
                <pre>&lt;!-- v1.31.13+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.31.13, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#changelog-since-v13112).&#xD;&#xA;&#xD;&#xA;## Changes since v1.31.12+k3s1:&#xD;&#xA;&#xD;&#xA;* Backports for 2025-09 [(#12887)](https://github.com/k3s-io/k3s/pull/12887)&#xD;&#xA;  * Wire cri-dockerd --log-level=debug up to k3s --debug flag&#xD;&#xA;  * Fix spegel logging and startup sequence&#xD;&#xA;  * Update to runc v1.2.7&#xD;&#xA;  * Do not bootstrap etcd-only nodes from existing supervisor&#xD;&#xA;  * Add retry on etcd MemberAdd timeout&#xD;&#xA;  * Bump containerd to v2.1.4&#xD;&#xA;  * Retry CRD creation in case of conflict&#xD;&#xA;  * Wire up kine metrics&#xD;&#xA;  * Fix etcd join timeout handling&#xD;&#xA;  * Bump k3s-root to v0.15.0&#xD;&#xA;  * Move data dir into position before creating CNI symlinks&#xD;&#xA;* Update to v1.31.13-k3s1 and Go 1.23.12 [(#12893)](https://github.com/k3s-io/k3s/pull/12893)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.31.13](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v13113) |&#xD;&#xA;| Kine | [v0.14.0](https://github.com/k3s-io/kine/releases/tag/v0.14.0) |&#xD;&#xA;| SQLite | [3.50.4](https://sqlite.org/releaselog/3_50_4.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.1.4-k3s1.32](https://github.com/k3s-io/containerd/releases/tag/v2.1.4-k3s1.32) |&#xD;&#xA;| Runc | [v1.2.7](https://github.com/opencontainers/runc/releases/tag/v1.2.7) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) |&#xD;&#xA;| Traefik | [v2.11.24](https://github.com/traefik/traefik/releases/tag/v2.11.24) |&#xD;&#xA;| CoreDNS | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | &#xD;&#xA;| Helm-controller | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.31.13-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.32.8+k3s1</summary>
                <pre>&lt;!-- v1.32.8+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.32.8, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1327).&#xD;&#xA;&#xD;&#xA;## Changes since v1.32.7+k3s1:&#xD;&#xA;&#xD;&#xA;* Add retention flag specific for s3 [(#12695)](https://github.com/k3s-io/k3s/pull/12695)&#xD;&#xA;* Backports for August [(#12719)](https://github.com/k3s-io/k3s/pull/12719)&#xD;&#xA;* Bump coredns to 1.12.3 [(#12730)](https://github.com/k3s-io/k3s/pull/12730)&#xD;&#xA;* - Bump metrics-server to v0.8.0 [(#12742)](https://github.com/k3s-io/k3s/pull/12742)&#xD;&#xA;* Fix cert startup check events [(#12747)](https://github.com/k3s-io/k3s/pull/12747)&#xD;&#xA;* Emit certs OK event on startup, if no certs need renewal [(#12761)](https://github.com/k3s-io/k3s/pull/12761)&#xD;&#xA;* Update metric help to be more descriptive. [(#12765)](https://github.com/k3s-io/k3s/pull/12765)&#xD;&#xA;* Update to v1.32.8-k3s1 and Go 1.23.11 [(#12759)](https://github.com/k3s-io/k3s/pull/12759)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.32.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1328) |&#xD;&#xA;| Kine | [v0.13.17](https://github.com/k3s-io/kine/releases/tag/v0.13.17) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s2.32](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2.32) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | &#xD;&#xA;| Helm-controller | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.32.9+k3s1</summary>
                <pre>&lt;!-- v1.32.9+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.32.9, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1328).&#xD;&#xA;&#xD;&#xA;## Changes since v1.32.8+k3s1:&#xD;&#xA;&#xD;&#xA;* Backports for 2025-09 [(#12886)](https://github.com/k3s-io/k3s/pull/12886)&#xD;&#xA;  * Wire cri-dockerd --log-level=debug up to k3s --debug flag&#xD;&#xA;  * Fix spegel logging and startup sequence&#xD;&#xA;  * Update to runc v1.2.7&#xD;&#xA;  * Do not bootstrap etcd-only nodes from existing supervisor&#xD;&#xA;  * Add retry on etcd MemberAdd timeout&#xD;&#xA;  * Bump containerd to v2.1.4&#xD;&#xA;  * Retry CRD creation in case of conflict&#xD;&#xA;  * Wire up kine metrics&#xD;&#xA;  * Fix etcd join timeout handling&#xD;&#xA;  * Bump k3s-root to v0.15.0&#xD;&#xA;  * Move data dir into position before creating CNI symlinks&#xD;&#xA;* Update to v1.32.9-k3s1 and Go 1.23.12 [(#12894)](https://github.com/k3s-io/k3s/pull/12894)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.32.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1329) |&#xD;&#xA;| Kine | [v0.14.0](https://github.com/k3s-io/kine/releases/tag/v0.14.0) |&#xD;&#xA;| SQLite | [3.50.4](https://sqlite.org/releaselog/3_50_4.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.1.4-k3s1.32](https://github.com/k3s-io/containerd/releases/tag/v2.1.4-k3s1.32) |&#xD;&#xA;| Runc | [v1.2.7](https://github.com/opencontainers/runc/releases/tag/v1.2.7) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | &#xD;&#xA;| Helm-controller | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.32.9-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.33.4+k3s1</summary>
                <pre>&lt;!-- v1.33.4+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.33.4, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#changelog-since-v1333).&#xD;&#xA;&#xD;&#xA;## Changes since v1.33.3+k3s1:&#xD;&#xA;&#xD;&#xA;* Add retention flag specific for s3 [(#12694)](https://github.com/k3s-io/k3s/pull/12694)&#xD;&#xA;* Backports for August [(#12718)](https://github.com/k3s-io/k3s/pull/12718)&#xD;&#xA;* Bump coredns to 1.12.3 [(#12728)](https://github.com/k3s-io/k3s/pull/12728)&#xD;&#xA;* - Bump metrics-server to v0.8.0 [(#12741)](https://github.com/k3s-io/k3s/pull/12741)&#xD;&#xA;* Fix cert startup check events [(#12746)](https://github.com/k3s-io/k3s/pull/12746)&#xD;&#xA;* Emit certs OK event on startup, if no certs need renewal [(#12760)](https://github.com/k3s-io/k3s/pull/12760)&#xD;&#xA;* Update to v1.33.4-k3s1 and Go 1.24.5 [(#12758)](https://github.com/k3s-io/k3s/pull/12758)&#xD;&#xA;* Update metric help to be more descriptive. [(#12764)](https://github.com/k3s-io/k3s/pull/12764)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.33.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v1334) |&#xD;&#xA;| Kine | [v0.13.17](https://github.com/k3s-io/kine/releases/tag/v0.13.17) |&#xD;&#xA;| SQLite | [3.49.1](https://sqlite.org/releaselog/3_49_1.html) |&#xD;&#xA;| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |&#xD;&#xA;| Containerd | [v2.0.5-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.5-k3s2) |&#xD;&#xA;| Runc | [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6) |&#xD;&#xA;| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | &#xD;&#xA;| Metrics-server | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) |&#xD;&#xA;| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |&#xD;&#xA;| CoreDNS | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | &#xD;&#xA;| Helm-controller | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) |&#xD;&#xA;| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.33.4-rc1+k3s1</summary>
            </details>
            <details>
                <summary>v1.34.0-rc1+k3s1</summary>
            </details>
        </details>
        <a href="https://github.com/mprochowski/k3s-cluster-gitops/actions/runs/17990906622">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

