### PR TITLE
k3s-io/k3s: bump version to v1.33.13+k3s2

### DIFF
--- a/.charts/1-infrastructure/system-upgrade-controller/values.yaml
+++ b/.charts/1-infrastructure/system-upgrade-controller/values.yaml
@@ -1,2 +1,2 @@
 kubernetes:
-  version: v1.33.8+k3s1
+  version: v1.33.10+k3s1

--- a/1-infrastructure/system-upgrade-controller/plans.yaml
+++ b/1-infrastructure/system-upgrade-controller/plans.yaml
@@ -18,7 +18,7 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.33.8+k3s1
+  version: v1.33.10+k3s1
 ---
 # Source: system-upgrade-controller/templates/plans.yaml
 # Agent plan
@@ -42,4 +42,4 @@ spec:
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
-  version: v1.33.8+k3s1
+  version: v1.33.10+k3s1


### PR DESCRIPTION



<Actions>
    <action id="32378aa2665b229d8619fccc2da26de763ac7ea67bcad573ba096abdf76f9240">
        <h3>k3s-io/k3s</h3>
        <details id="37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f">
            <summary>k3s-io/k3s: bump version to v1.33.13+k3s2</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.kubernetes.version&#34; updated from &#34;v1.33.13+k3s1&#34; to &#34;v1.33.13+k3s2&#34;, in file &#34;.charts/1-infrastructure/system-upgrade-controller/values.yaml&#34;</p>
            <details>
                <summary>v1.36.3-rc1+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [release-1.36] Bump dynamiclistener to v0.9.0-rc.2 for wildcard tls-san support by @Eshaan-Lumba in https://github.com/k3s-io/k3s/pull/14312&#xA;* [Release-1.36] July Testing Backports by @dereknola in https://github.com/k3s-io/k3s/pull/14328&#xA;* [Release-1.36] July K3s Build Rework + GHA bumps by @dereknola in https://github.com/k3s-io/k3s/pull/14332&#xA;* [release-1.36] Backports for 2026-07 by @brandond in https://github.com/k3s-io/k3s/pull/14348&#xA;* [Release-1.36] Bump mirrored-pause to 3.10.2  by @dereknola in https://github.com/k3s-io/k3s/pull/14389&#xA;* [Release 1.36] Bump Traefik to v3.7.7 by @manuelbuil in https://github.com/k3s-io/k3s/pull/14381&#xA;* [release-1.36] More backports for 2026-07 by @brandond in https://github.com/k3s-io/k3s/pull/14406&#xA;* [release-1.36] Fix typo in snapshot prune event by @brandond in https://github.com/k3s-io/k3s/pull/14411&#xA;* [release-1.36] Bump rancher/mirrored-coredns-coredns image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14424&#xA;* [release-1.36] Bump golang:alpine image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14432&#xA;* [release-1.36] Bump rancher/mirrored-metrics-server image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14437&#xA;* [Release 1.36] Use new Traefik v3.7.8 by @manuelbuil in https://github.com/k3s-io/k3s/pull/14426&#xA;* [release-1.36] Bump helm-controller and klipper-helm for `--force-conflicts` support by @brandond in https://github.com/k3s-io/k3s/pull/14442&#xA;* [release-1.36] Bump k3s-io/kubernetes and Go references by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14456&#xA;* [release-1.36] Bump etcd to v3.6.14 by @brandond in https://github.com/k3s-io/k3s/pull/14461&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.36.2+k3s1...v1.36.3-rc1+k3s1</pre>
            </details>
            <details>
                <summary>v1.36.2+k3s1</summary>
                <pre>&lt;!-- v1.36.2+k3s1 --&gt;&#xD;&#xA;&gt; [!WARNING]&#xD;&#xA;&gt; This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.36.2, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#changelog-since-v1361).&#xD;&#xA;&#xD;&#xA;## Changes since v1.36.1+k3s1:&#xD;&#xA;&#xD;&#xA;* Backport GitHub Action SHA pin updates from main [(#14127)](https://github.com/k3s-io/k3s/pull/14127)&#xD;&#xA;* Backports for 2026-06 [(#14151)](https://github.com/k3s-io/k3s/pull/14151)&#xD;&#xA;* Bump v3.7.4 Traefik [(#14193)](https://github.com/k3s-io/k3s/pull/14193)&#xD;&#xA;* More backports for 2026-06 [(#14211)](https://github.com/k3s-io/k3s/pull/14211)&#xD;&#xA;* Testing Backports 2026-06 [(#14213)](https://github.com/k3s-io/k3s/pull/14213)&#xD;&#xA;* Bump klipper-helm for CVE reasons (#14235) [(#14236)](https://github.com/k3s-io/k3s/pull/14236)&#xD;&#xA;* Bump containerd with the fix for []byte [(#14243)](https://github.com/k3s-io/k3s/pull/14243)&#xD;&#xA;* Update to v1.36.2-k3s1 and Go 1.26.4 [(#14230)](https://github.com/k3s-io/k3s/pull/14230)&#xD;&#xA;* Bump containerd to v2.3.2-k3s1 [(#14254)](https://github.com/k3s-io/k3s/pull/14254)&#xD;&#xA;* Bump cri-api and containerd for upstream env string fix [(#14277)](https://github.com/k3s-io/k3s/pull/14277)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.36.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1362) |&#xD;&#xA;| Kine | [v0.16.1](https://github.com/k3s-io/kine/releases/tag/v0.16.1) |&#xD;&#xA;| SQLite | [3.53.0](https://sqlite.org/releaselog/3_53_0.html) |&#xD;&#xA;| Etcd | [v3.6.12-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1) |&#xD;&#xA;| Containerd | [v2.3.2-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.3.2-k3s2) |&#xD;&#xA;| Runc | [v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) |&#xD;&#xA;| Flannel | [v0.28.4](https://github.com/flannel-io/flannel/releases/tag/v0.28.4) | &#xD;&#xA;| Metrics-server | [v0.8.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1) |&#xD;&#xA;| Traefik | [v3.7.4](https://github.com/traefik/traefik/releases/tag/v3.7.4) |&#xD;&#xA;| CoreDNS | [v1.14.4](https://github.com/coredns/coredns/releases/tag/v1.14.4) | &#xD;&#xA;| Helm-controller | [v0.17.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1) |&#xD;&#xA;| Local-path-provisioner | [v0.0.36](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.36.2-rc3+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [release-1.36] Bump cri-api and containerd for upstream env string fix by @brandond in https://github.com/k3s-io/k3s/pull/14277&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.36.2-rc2+k3s1...v1.36.2-rc3+k3s1</pre>
            </details>
            <details>
                <summary>v1.36.2-rc2+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [Release-1.36] Bump containerd to v2.3.2-k3s1 by @vitorsavian in https://github.com/k3s-io/k3s/pull/14254&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.36.2-rc1+k3s1...v1.36.2-rc2+k3s1</pre>
            </details>
            <details>
                <summary>v1.36.2-rc1+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [Release-1.36] Backport GitHub Action SHA pin updates from main by @dereknola in https://github.com/k3s-io/k3s/pull/14127&#xA;* [release-1.36] Backports for 2026-06 by @brandond in https://github.com/k3s-io/k3s/pull/14151&#xA;* [Release 1.36] Bump v3.7.4 Traefik by @manuelbuil in https://github.com/k3s-io/k3s/pull/14193&#xA;* [release-1.36] More backports for 2026-06 by @brandond in https://github.com/k3s-io/k3s/pull/14211&#xA;* [Release-1.36] Testing Backports 2026-06 by @dereknola in https://github.com/k3s-io/k3s/pull/14213&#xA;* [Release-1.36] Bump klipper-helm for CVE reasons (#14235) by @vitorsavian in https://github.com/k3s-io/k3s/pull/14236&#xA;* [Release-1.36] Bump containerd with the fix for []byte by @vitorsavian in https://github.com/k3s-io/k3s/pull/14243&#xA;* [release-1.36] Update to v1.36.2-k3s1 and Go 1.26.4 by @rafaelbreno in https://github.com/k3s-io/k3s/pull/14230&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.36.1+k3s1...v1.36.2-rc1+k3s1</pre>
            </details>
            <details>
                <summary>v1.36.1+k3s1</summary>
                <pre>&lt;!-- v1.36.1+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.36.1, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#changelog-since-v1360).&#xD;&#xA;&#xD;&#xA;## Changes since v1.36.0+k3s1:&#xD;&#xA;&#xD;&#xA;* Backports for 2026-05 [(#14032)](https://github.com/k3s-io/k3s/pull/14032)&#xD;&#xA;* Update rancher/local-path-provisioner image version [(#14042)](https://github.com/k3s-io/k3s/pull/14042)&#xD;&#xA;* Update to v1.36.1-k3s1 and Go 1.26.2 [(#14051)](https://github.com/k3s-io/k3s/pull/14051)&#xD;&#xA;* Bump klipper-helm image tag [(#14055)](https://github.com/k3s-io/k3s/pull/14055)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.36.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1361) |&#xD;&#xA;| Kine | [v0.15.0](https://github.com/k3s-io/kine/releases/tag/v0.15.0) |&#xD;&#xA;| SQLite | [3.53.0](https://sqlite.org/releaselog/3_53_0.html) |&#xD;&#xA;| Etcd | [v3.6.7-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.6.7-k3s1) |&#xD;&#xA;| Containerd | [v2.2.3-k3s1](https://github.com/k3s-io/containerd/releases/tag/v2.2.3-k3s1) |&#xD;&#xA;| Runc | [v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) |&#xD;&#xA;| Flannel | [v0.28.4](https://github.com/flannel-io/flannel/releases/tag/v0.28.4) | &#xD;&#xA;| Metrics-server | [v0.8.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1) |&#xD;&#xA;| Traefik | [v3.6.13](https://github.com/traefik/traefik/releases/tag/v3.6.13) |&#xD;&#xA;| CoreDNS | [v1.14.3](https://github.com/coredns/coredns/releases/tag/v1.14.3) | &#xD;&#xA;| Helm-controller | [v0.17.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1) |&#xD;&#xA;| Local-path-provisioner | [v0.0.36](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
            <details>
                <summary>v1.36.1-rc1+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [release-1.36] Backports for 2026-05 by @brandond in https://github.com/k3s-io/k3s/pull/14032&#xA;* [release-1.36] Update rancher/local-path-provisioner image version by @brandond in https://github.com/k3s-io/k3s/pull/14042&#xA;* [release-1.36] Update to v1.36.1-k3s1 and Go 1.26.2 by @rafaelbreno in https://github.com/k3s-io/k3s/pull/14051&#xA;* [release-1.36] Bump klipper-helm image tag by @brandond in https://github.com/k3s-io/k3s/pull/14055&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.36.0+k3s1...v1.36.1-rc1+k3s1</pre>
            </details>
            <details>
                <summary>v1.35.7-rc1+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [Release-1.35] July Testing Backports by @dereknola in https://github.com/k3s-io/k3s/pull/14329&#xA;* [Release-1.35] July K3s Build Rework + GHA bumps by @dereknola in https://github.com/k3s-io/k3s/pull/14333&#xA;* [release-1.35] Backports for 2026-07 by @brandond in https://github.com/k3s-io/k3s/pull/14370&#xA;* [Release-1.35] Bump mirrored-pause to 3.10.2  by @dereknola in https://github.com/k3s-io/k3s/pull/14390&#xA;* [Release 1.35] Bump Traefik to v3.7.7 by @manuelbuil in https://github.com/k3s-io/k3s/pull/14380&#xA;* [release-1.35] More backports for 2026-07 by @brandond in https://github.com/k3s-io/k3s/pull/14407&#xA;* [release-1.35] Fix typo in snapshot prune event by @brandond in https://github.com/k3s-io/k3s/pull/14412&#xA;* [release-1.35] Bump rancher/mirrored-coredns-coredns image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14421&#xA;* [release-1.35] Bump golang:alpine image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14431&#xA;* [release-1.35] Bump rancher/mirrored-metrics-server image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14439&#xA;* [Release 1.35] Use new Traefik v3.7.8 by @manuelbuil in https://github.com/k3s-io/k3s/pull/14425&#xA;* [release-1.35] Bump helm-controller and klipper-helm for `--force-conflicts` support by @brandond in https://github.com/k3s-io/k3s/pull/14443&#xA;* [release-1.35] Bump k3s-io/kubernetes and Go references by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14455&#xA;* [release-1.35] Bump etcd to v3.6.14 by @brandond in https://github.com/k3s-io/k3s/pull/14462&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.35.6+k3s1...v1.35.7-rc1+k3s1</pre>
            </details>
            <details>
                <summary>v1.35.6+k3s1</summary>
                <pre>&lt;!-- v1.35.6+k3s1 --&gt;&#xD;&#xA;&gt; [!WARNING]&#xD;&#xA;&gt; This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.35.6, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#changelog-since-v1355).&#xD;&#xA;&#xD;&#xA;## Changes since v1.35.5+k3s1:&#xD;&#xA;&#xD;&#xA;* Backport GitHub Action SHA pin updates from main [(#14126)](https://github.com/k3s-io/k3s/pull/14126)&#xD;&#xA;* Backports for 2026-06 [(#14152)](https://github.com/k3s-io/k3s/pull/14152)&#xD;&#xA;* Bump v3.7.4 Traefik [(#14194)](https://github.com/k3s-io/k3s/pull/14194)&#xD;&#xA;* More backports for 2026-06 [(#14212)](https://github.com/k3s-io/k3s/pull/14212)&#xD;&#xA;* Testing Backports 2026-06 [(#14214)](https://github.com/k3s-io/k3s/pull/14214)&#xD;&#xA;* Bump klipper-helm for CVE reasons (#14235) [(#14237)](https://github.com/k3s-io/k3s/pull/14237)&#xD;&#xA;* Bump containerd to fix []byte envvar value [(#14241)](https://github.com/k3s-io/k3s/pull/14241)&#xD;&#xA;* Update to v1.35.6-k3s1 and Go 1.25.11 [(#14229)](https://github.com/k3s-io/k3s/pull/14229)&#xD;&#xA;* Bump containerd for 1.35 [(#14251)](https://github.com/k3s-io/k3s/pull/14251)&#xD;&#xA;* Bump cri-api and containerd for upstream env string fix [(#14278)](https://github.com/k3s-io/k3s/pull/14278)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.35.6](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#v1356) |&#xD;&#xA;| Kine | [v0.16.1](https://github.com/k3s-io/kine/releases/tag/v0.16.1) |&#xD;&#xA;| SQLite | [3.53.0](https://sqlite.org/releaselog/3_53_0.html) |&#xD;&#xA;| Etcd | [v3.6.12-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1) |&#xD;&#xA;| Containerd | [v2.2.5-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s2) |&#xD;&#xA;| Runc | [v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) |&#xD;&#xA;| Flannel | [v0.28.4](https://github.com/flannel-io/flannel/releases/tag/v0.28.4) | &#xD;&#xA;| Metrics-server | [v0.8.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1) |&#xD;&#xA;| Traefik | [v3.7.4](https://github.com/traefik/traefik/releases/tag/v3.7.4) |&#xD;&#xA;| CoreDNS | [v1.14.4](https://github.com/coredns/coredns/releases/tag/v1.14.4) | &#xD;&#xA;| Helm-controller | [v0.17.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1) |&#xD;&#xA;| Local-path-provisioner | [v0.0.36](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.35.6-rc3+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [release-1.35] Bump cri-api and containerd for upstream env string fix by @brandond in https://github.com/k3s-io/k3s/pull/14278&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.35.6-rc2+k3s1...v1.35.6-rc3+k3s1</pre>
            </details>
            <details>
                <summary>v1.35.6-rc2+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [Release-1.35] Bump containerd for 1.35 by @vitorsavian in https://github.com/k3s-io/k3s/pull/14251&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.35.6-rc1+k3s1...v1.35.6-rc2+k3s1</pre>
            </details>
            <details>
                <summary>v1.35.6-rc1+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [Release-1.35] Backport GitHub Action SHA pin updates from main by @dereknola in https://github.com/k3s-io/k3s/pull/14126&#xA;* [release-1.35] Backports for 2026-06 by @brandond in https://github.com/k3s-io/k3s/pull/14152&#xA;* [Release 1.35] Bump v3.7.4 Traefik by @manuelbuil in https://github.com/k3s-io/k3s/pull/14194&#xA;* [release-1.35] More backports for 2026-06 by @brandond in https://github.com/k3s-io/k3s/pull/14212&#xA;* [Release-1.35] Testing Backports 2026-06 by @dereknola in https://github.com/k3s-io/k3s/pull/14214&#xA;* [Release-1.35] Bump klipper-helm for CVE reasons (#14235) by @vitorsavian in https://github.com/k3s-io/k3s/pull/14237&#xA;* [Release-1.35] Bump containerd to fix []byte envvar value by @vitorsavian in https://github.com/k3s-io/k3s/pull/14241&#xA;* [release-1.35] Update to v1.35.6-k3s1 and Go 1.25.11 by @rafaelbreno in https://github.com/k3s-io/k3s/pull/14229&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.35.5+k3s1...v1.35.6-rc1+k3s1</pre>
            </details>
            <details>
                <summary>v1.35.5+k3s1</summary>
                <pre>&lt;!-- v1.35.5+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.35.5, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#changelog-since-v1354).&#xD;&#xA;&#xD;&#xA;## Changes since v1.35.4+k3s1:&#xD;&#xA;&#xD;&#xA;* Backports for 2026-05 [(#14033)](https://github.com/k3s-io/k3s/pull/14033)&#xD;&#xA;* Update rancher/local-path-provisioner image version [(#14043)](https://github.com/k3s-io/k3s/pull/14043)&#xD;&#xA;* Update to v1.35.5-k3s1 and Go 1.25.9 [(#14050)](https://github.com/k3s-io/k3s/pull/14050)&#xD;&#xA;* Bump klipper-helm image tag [(#14056)](https://github.com/k3s-io/k3s/pull/14056)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.35.5](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#v1355) |&#xD;&#xA;| Kine | [v0.15.0](https://github.com/k3s-io/kine/releases/tag/v0.15.0) |&#xD;&#xA;| SQLite | [3.53.0](https://sqlite.org/releaselog/3_53_0.html) |&#xD;&#xA;| Etcd | [v3.6.7-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.6.7-k3s1) |&#xD;&#xA;| Containerd | [v2.2.3-k3s1](https://github.com/k3s-io/containerd/releases/tag/v2.2.3-k3s1) |&#xD;&#xA;| Runc | [v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) |&#xD;&#xA;| Flannel | [v0.28.4](https://github.com/flannel-io/flannel/releases/tag/v0.28.4) | &#xD;&#xA;| Metrics-server | [v0.8.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1) |&#xD;&#xA;| Traefik | [v3.6.13](https://github.com/traefik/traefik/releases/tag/v3.6.13) |&#xD;&#xA;| CoreDNS | [v1.14.3](https://github.com/coredns/coredns/releases/tag/v1.14.3) | &#xD;&#xA;| Helm-controller | [v0.17.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1) |&#xD;&#xA;| Local-path-provisioner | [v0.0.36](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
            <details>
                <summary>v1.35.5-rc1+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [release-1.35] Backports for 2026-05 by @brandond in https://github.com/k3s-io/k3s/pull/14033&#xA;* [release-1.35] Update rancher/local-path-provisioner image version by @brandond in https://github.com/k3s-io/k3s/pull/14043&#xA;* [release-1.35] Update to v1.35.5-k3s1 and Go 1.25.9 by @rafaelbreno in https://github.com/k3s-io/k3s/pull/14050&#xA;* [release-1.35] Bump klipper-helm image tag by @brandond in https://github.com/k3s-io/k3s/pull/14056&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.35.4+k3s1...v1.35.5-rc1+k3s1</pre>
            </details>
            <details>
                <summary>v1.34.10-rc1+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [Release-1.34] July Testing Backports by @dereknola in https://github.com/k3s-io/k3s/pull/14330&#xA;* [Release-1.34] July K3s Build Rework + GHA bumps by @dereknola in https://github.com/k3s-io/k3s/pull/14335&#xA;* [release-1.34] Backports for 2026-07 by @brandond in https://github.com/k3s-io/k3s/pull/14371&#xA;* [Release-1.34] Bump mirrored-pause to 3.10.2  by @dereknola in https://github.com/k3s-io/k3s/pull/14391&#xA;* [Release 1.34] Bump Traefik to v3.7.7 by @manuelbuil in https://github.com/k3s-io/k3s/pull/14379&#xA;* [release-1.34] More backports for 2026-07 by @brandond in https://github.com/k3s-io/k3s/pull/14408&#xA;* [release-1.34] Fix typo in snapshot prune event by @brandond in https://github.com/k3s-io/k3s/pull/14413&#xA;* [release-1.34] Bump rancher/mirrored-coredns-coredns image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14423&#xA;* [release-1.34] Bump golang:alpine image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14430&#xA;* [release-1.34] Bump rancher/mirrored-metrics-server image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14436&#xA;* [Release 1.34] Use new Traefik v3.7.8 by @manuelbuil in https://github.com/k3s-io/k3s/pull/14427&#xA;* [release-1.34] Bump helm-controller and klipper-helm for `--force-conflicts` support by @brandond in https://github.com/k3s-io/k3s/pull/14444&#xA;* [release-1.34] Bump k3s-io/kubernetes and Go references by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14453&#xA;* [release-1.34] Bump etcd to v3.6.14 by @brandond in https://github.com/k3s-io/k3s/pull/14463&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.34.9+k3s1...v1.34.10-rc1+k3s1</pre>
            </details>
            <details>
                <summary>v1.34.9+k3s1</summary>
                <pre>&lt;!-- v1.34.9+k3s1 --&gt;&#xD;&#xA;&gt; [!WARNING]&#xD;&#xA;&gt; This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.34.9, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#changelog-since-v1348).&#xD;&#xA;&#xD;&#xA;## Changes since v1.34.8+k3s1:&#xD;&#xA;&#xD;&#xA;* Backport GitHub Action SHA pin updates from main [(#14125)](https://github.com/k3s-io/k3s/pull/14125)&#xD;&#xA;* Backports for 2026-06 [(#14154)](https://github.com/k3s-io/k3s/pull/14154)&#xD;&#xA;* Bump v3.7.4 Traefik [(#14195)](https://github.com/k3s-io/k3s/pull/14195)&#xD;&#xA;* More backports for 2026-06 [(#14216)](https://github.com/k3s-io/k3s/pull/14216)&#xD;&#xA;* Testing Backports 2026-06 [(#14215)](https://github.com/k3s-io/k3s/pull/14215)&#xD;&#xA;* Bump klipper-helm for CVE reasons [(#14239)](https://github.com/k3s-io/k3s/pull/14239)&#xD;&#xA;* Bump containerd with the fix for []byte [(#14242)](https://github.com/k3s-io/k3s/pull/14242)&#xD;&#xA;* Update to v1.34.9-k3s1 and Go 1.25.11 [(#14228)](https://github.com/k3s-io/k3s/pull/14228)&#xD;&#xA;* Bump containerd to v2.2.5-k3s1 [(#14255)](https://github.com/k3s-io/k3s/pull/14255)&#xD;&#xA;* Bump cri-api and containerd for upstream env string fix [(#14279)](https://github.com/k3s-io/k3s/pull/14279)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.34.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1349) |&#xD;&#xA;| Kine | [v0.16.1](https://github.com/k3s-io/kine/releases/tag/v0.16.1) |&#xD;&#xA;| SQLite | [3.53.0](https://sqlite.org/releaselog/3_53_0.html) |&#xD;&#xA;| Etcd | [v3.6.12-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1) |&#xD;&#xA;| Containerd | [v2.2.5-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s2) |&#xD;&#xA;| Runc | [v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) |&#xD;&#xA;| Flannel | [v0.28.4](https://github.com/flannel-io/flannel/releases/tag/v0.28.4) | &#xD;&#xA;| Metrics-server | [v0.8.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1) |&#xD;&#xA;| Traefik | [v3.7.4](https://github.com/traefik/traefik/releases/tag/v3.7.4) |&#xD;&#xA;| CoreDNS | [v1.14.4](https://github.com/coredns/coredns/releases/tag/v1.14.4) | &#xD;&#xA;| Helm-controller | [v0.17.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1) |&#xD;&#xA;| Local-path-provisioner | [v0.0.36](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.34.9-rc3+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [release-1.34] Bump cri-api and containerd for upstream env string fix by @brandond in https://github.com/k3s-io/k3s/pull/14279&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.34.9-rc2+k3s1...v1.34.9-rc3+k3s1</pre>
            </details>
            <details>
                <summary>v1.34.9-rc2+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [Release-1.34] Bump containerd to v2.2.5-k3s1 by @vitorsavian in https://github.com/k3s-io/k3s/pull/14255&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.34.9-rc1+k3s1...v1.34.9-rc2+k3s1</pre>
            </details>
            <details>
                <summary>v1.34.9-rc1+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [Release-1.34] Backport GitHub Action SHA pin updates from main by @dereknola in https://github.com/k3s-io/k3s/pull/14125&#xA;* [release-1.34] Backports for 2026-06 by @brandond in https://github.com/k3s-io/k3s/pull/14154&#xA;* [Release 1.34] Bump v3.7.4 Traefik by @manuelbuil in https://github.com/k3s-io/k3s/pull/14195&#xA;* [release-1.34] More backports for 2026-06 by @brandond in https://github.com/k3s-io/k3s/pull/14216&#xA;* [Release-1.34] Testing Backports 2026-06 by @dereknola in https://github.com/k3s-io/k3s/pull/14215&#xA;* [Release-1.34] Bump klipper-helm for CVE reasons by @vitorsavian in https://github.com/k3s-io/k3s/pull/14239&#xA;* [Release-1.34] Bump containerd with the fix for []byte by @vitorsavian in https://github.com/k3s-io/k3s/pull/14242&#xA;* [release-1.34] Update to v1.34.9-k3s1 and Go 1.25.11 by @rafaelbreno in https://github.com/k3s-io/k3s/pull/14228&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.34.8+k3s1...v1.34.9-rc1+k3s1</pre>
            </details>
            <details>
                <summary>v1.34.8+k3s1</summary>
                <pre>&lt;!-- v1.34.8+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.34.8, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#changelog-since-v1347).&#xD;&#xA;&#xD;&#xA;## Changes since v1.34.7+k3s1:&#xD;&#xA;&#xD;&#xA;* Backports for 2026-05 [(#14034)](https://github.com/k3s-io/k3s/pull/14034)&#xD;&#xA;* Update rancher/local-path-provisioner image version [(#14044)](https://github.com/k3s-io/k3s/pull/14044)&#xD;&#xA;* Update to v1.34.8-k3s1 and Go 1.25.9 [(#14049)](https://github.com/k3s-io/k3s/pull/14049)&#xD;&#xA;* Bump klipper-helm image tag [(#14057)](https://github.com/k3s-io/k3s/pull/14057)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.34.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1348) |&#xD;&#xA;| Kine | [v0.15.0](https://github.com/k3s-io/kine/releases/tag/v0.15.0) |&#xD;&#xA;| SQLite | [3.53.0](https://sqlite.org/releaselog/3_53_0.html) |&#xD;&#xA;| Etcd | [v3.6.7-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.6.7-k3s1) |&#xD;&#xA;| Containerd | [v2.2.3-k3s1](https://github.com/k3s-io/containerd/releases/tag/v2.2.3-k3s1) |&#xD;&#xA;| Runc | [v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) |&#xD;&#xA;| Flannel | [v0.28.4](https://github.com/flannel-io/flannel/releases/tag/v0.28.4) | &#xD;&#xA;| Metrics-server | [v0.8.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1) |&#xD;&#xA;| Traefik | [v3.6.13](https://github.com/traefik/traefik/releases/tag/v3.6.13) |&#xD;&#xA;| CoreDNS | [v1.14.3](https://github.com/coredns/coredns/releases/tag/v1.14.3) | &#xD;&#xA;| Helm-controller | [v0.17.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1) |&#xD;&#xA;| Local-path-provisioner | [v0.0.36](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
            <details>
                <summary>v1.34.8-rc1+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [release-1.34] Backports for 2026-05 by @brandond in https://github.com/k3s-io/k3s/pull/14034&#xA;* [release-1.34] Update rancher/local-path-provisioner image version by @brandond in https://github.com/k3s-io/k3s/pull/14044&#xA;* [release-1.34] Update to v1.34.8-k3s1 and Go 1.25.9 by @rafaelbreno in https://github.com/k3s-io/k3s/pull/14049&#xA;* [release-1.34] Bump klipper-helm image tag by @brandond in https://github.com/k3s-io/k3s/pull/14057&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.34.7+k3s1...v1.34.8-rc1+k3s1</pre>
            </details>
            <details>
                <summary>v1.33.13+k3s2</summary>
                <pre>&lt;!-- v1.33.13+k3s2 --&gt;&#xD;&#xA;&gt; [!WARNING]&#xD;&#xA;&gt; This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.33.13, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#changelog-since-v13313).&#xD;&#xA;&#xD;&#xA;## Changes since v1.33.13+k3s1:&#xD;&#xA;&#xD;&#xA;* July Testing Backports [(#14331)](https://github.com/k3s-io/k3s/pull/14331)&#xD;&#xA;* July K3s Build Rework + GHA bumps [(#14334)](https://github.com/k3s-io/k3s/pull/14334)&#xD;&#xA;* Backports for 2026-07 [(#14372)](https://github.com/k3s-io/k3s/pull/14372)&#xD;&#xA;* Bump mirrored-pause to 3.10.2 [(#14392)](https://github.com/k3s-io/k3s/pull/14392)&#xD;&#xA;* Bump Traefik to v3.7.7 [(#14378)](https://github.com/k3s-io/k3s/pull/14378)&#xD;&#xA;* More backports for 2026-07 [(#14409)](https://github.com/k3s-io/k3s/pull/14409)&#xD;&#xA;* Fix typo in snapshot prune event [(#14414)](https://github.com/k3s-io/k3s/pull/14414)&#xD;&#xA;* Bump rancher/mirrored-coredns-coredns image version [(#14422)](https://github.com/k3s-io/k3s/pull/14422)&#xD;&#xA;* Bump golang:alpine image version [(#14433)](https://github.com/k3s-io/k3s/pull/14433)&#xD;&#xA;* Bump rancher/mirrored-metrics-server image version [(#14438)](https://github.com/k3s-io/k3s/pull/14438)&#xD;&#xA;* Use new Traefik v3.7.8 [(#14428)](https://github.com/k3s-io/k3s/pull/14428)&#xD;&#xA;* Bump helm-controller and klipper-helm for `--force-conflicts` support [(#14445)](https://github.com/k3s-io/k3s/pull/14445)&#xD;&#xA;* Bump k3s-io/kubernetes and Go references [(#14454)](https://github.com/k3s-io/k3s/pull/14454)&#xD;&#xA;* Bump etcd to v3.6.14 [(#14464)](https://github.com/k3s-io/k3s/pull/14464)&#xD;&#xA;* Fix production builds always enabling Go coverage instrumentation [(#14469)](https://github.com/k3s-io/k3s/pull/14469)&#xD;&#xA;* Bump helm-controller and klipper-helm [(#14478)](https://github.com/k3s-io/k3s/pull/14478)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.33.13](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v13313) |&#xD;&#xA;| Kine | [v0.16.3](https://github.com/k3s-io/kine/releases/tag/v0.16.3) |&#xD;&#xA;| SQLite | [3.53.2](https://sqlite.org/releaselog/3_53_2.html) |&#xD;&#xA;| Etcd | [v3.6.14-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.6.14-k3s1) |&#xD;&#xA;| Containerd | [v2.2.5-k3s1.33](https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s1.33) |&#xD;&#xA;| Runc | [v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) |&#xD;&#xA;| Flannel | [v0.28.4](https://github.com/flannel-io/flannel/releases/tag/v0.28.4) | &#xD;&#xA;| Metrics-server | [v0.9.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.9.0) |&#xD;&#xA;| Traefik | [v3.7.8](https://github.com/traefik/traefik/releases/tag/v3.7.8) |&#xD;&#xA;| CoreDNS | [v1.14.6](https://github.com/coredns/coredns/releases/tag/v1.14.6) | &#xD;&#xA;| Helm-controller | [v0.16.26](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.26) |&#xD;&#xA;| Local-path-provisioner | [v0.0.36](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.33.13+k3s1</summary>
                <pre>&lt;!-- v1.33.13+k3s1 --&gt;&#xD;&#xA;&gt; [!WARNING]&#xD;&#xA;&gt; This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.33.13, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#changelog-since-v13312).&#xD;&#xA;&#xD;&#xA;## Changes since v1.33.12+k3s1:&#xD;&#xA;&#xD;&#xA;* Backports for 2026-06 [(#14155)](https://github.com/k3s-io/k3s/pull/14155)&#xD;&#xA;* Bump v3.7.4 Traefik [(#14196)](https://github.com/k3s-io/k3s/pull/14196)&#xD;&#xA;* More backports for 2026-06 [(#14218)](https://github.com/k3s-io/k3s/pull/14218)&#xD;&#xA;* Testing Backports 2026-06 [(#14217)](https://github.com/k3s-io/k3s/pull/14217)&#xD;&#xA;* Bump klipper-helm for CVE reasons [(#14238)](https://github.com/k3s-io/k3s/pull/14238)&#xD;&#xA;* Update to v1.33.13-k3s1 and Go 1.25.11 [(#14227)](https://github.com/k3s-io/k3s/pull/14227)&#xD;&#xA;* Bump containerd to v2.2.5-k3s1.33 [(#14256)](https://github.com/k3s-io/k3s/pull/14256)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.33.13](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v13313) |&#xD;&#xA;| Kine | [v0.16.1](https://github.com/k3s-io/kine/releases/tag/v0.16.1) |&#xD;&#xA;| SQLite | [3.53.0](https://sqlite.org/releaselog/3_53_0.html) |&#xD;&#xA;| Etcd | [v3.6.12-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1) |&#xD;&#xA;| Containerd | [v2.2.5-k3s1.33](https://github.com/k3s-io/containerd/releases/tag/v2.2.5-k3s1.33) |&#xD;&#xA;| Runc | [v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) |&#xD;&#xA;| Flannel | [v0.28.4](https://github.com/flannel-io/flannel/releases/tag/v0.28.4) | &#xD;&#xA;| Metrics-server | [v0.8.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1) |&#xD;&#xA;| Traefik | [v3.7.4](https://github.com/traefik/traefik/releases/tag/v3.7.4) |&#xD;&#xA;| CoreDNS | [v1.14.4](https://github.com/coredns/coredns/releases/tag/v1.14.4) | &#xD;&#xA;| Helm-controller | [v0.17.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1) |&#xD;&#xA;| Local-path-provisioner | [v0.0.36](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.33.13-rc2+k3s2</summary>
                <pre>## What&#39;s Changed&#xA;* [Release-1.33] Fix production builds always enabling Go coverage instrumentation by @mgfritch in https://github.com/k3s-io/k3s/pull/14469&#xA;* [release-1.33] Bump helm-controller and klipper-helm by @brandond in https://github.com/k3s-io/k3s/pull/14478&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.33.13-rc1+k3s2...v1.33.13-rc2+k3s2</pre>
            </details>
            <details>
                <summary>v1.33.13-rc2+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [Release-1.33] Bump containerd to v2.2.5-k3s1.33 by @vitorsavian in https://github.com/k3s-io/k3s/pull/14256&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.33.13-rc1+k3s1...v1.33.13-rc2+k3s1</pre>
            </details>
            <details>
                <summary>v1.33.13-rc1+k3s2</summary>
                <pre>## What&#39;s Changed&#xA;* [Release-1.33] July Testing Backports by @dereknola in https://github.com/k3s-io/k3s/pull/14331&#xA;* [Release-1.33] July K3s Build Rework + GHA bumps by @dereknola in https://github.com/k3s-io/k3s/pull/14334&#xA;* [release-1.33] Backports for 2026-07 by @brandond in https://github.com/k3s-io/k3s/pull/14372&#xA;* [Release-1.33] Bump mirrored-pause to 3.10.2  by @dereknola in https://github.com/k3s-io/k3s/pull/14392&#xA;* [Release 1.33] Bump Traefik to v3.7.7 by @manuelbuil in https://github.com/k3s-io/k3s/pull/14378&#xA;* [release-1.33] More backports for 2026-07 by @brandond in https://github.com/k3s-io/k3s/pull/14409&#xA;* [release-1.33] Fix typo in snapshot prune event by @brandond in https://github.com/k3s-io/k3s/pull/14414&#xA;* [release-1.33] Bump rancher/mirrored-coredns-coredns image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14422&#xA;* [release-1.33] Bump golang:alpine image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14433&#xA;* [release-1.33] Bump rancher/mirrored-metrics-server image version by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14438&#xA;* [Release 1.33] Use new Traefik v3.7.8 by @manuelbuil in https://github.com/k3s-io/k3s/pull/14428&#xA;* [release-1.33] Bump helm-controller and klipper-helm for `--force-conflicts` support by @brandond in https://github.com/k3s-io/k3s/pull/14445&#xA;* [release-1.33] Bump k3s-io/kubernetes and Go references by @github-actions[bot] in https://github.com/k3s-io/k3s/pull/14454&#xA;* [release-1.33] Bump etcd to v3.6.14 by @brandond in https://github.com/k3s-io/k3s/pull/14464&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.33.13+k3s1...v1.33.13-rc1+k3s2</pre>
            </details>
            <details>
                <summary>v1.33.13-rc1+k3s1</summary>
                <pre>## What&#39;s Changed&#xA;* [release-1.33] Backports for 2026-06 by @brandond in https://github.com/k3s-io/k3s/pull/14155&#xA;* [Release 1.33] Bump v3.7.4 Traefik by @manuelbuil in https://github.com/k3s-io/k3s/pull/14196&#xA;* [release-1.33] More backports for 2026-06 by @brandond in https://github.com/k3s-io/k3s/pull/14218&#xA;* [Release-1.33] Testing Backports 2026-06 by @dereknola in https://github.com/k3s-io/k3s/pull/14217&#xA;* [Release-1.33] Bump klipper-helm for CVE reasons by @vitorsavian in https://github.com/k3s-io/k3s/pull/14238&#xA;* [release-1.33] Update to v1.33.13-k3s1 and Go 1.25.11 by @rafaelbreno in https://github.com/k3s-io/k3s/pull/14227&#xA;&#xA;&#xA;**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.33.12+k3s1...v1.33.13-rc1+k3s1</pre>
            </details>
            <details>
                <summary>v1.33.12+k3s1</summary>
                <pre>&lt;!-- v1.33.12+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.33.12, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#changelog-since-v13311).&#xD;&#xA;&#xD;&#xA;## Changes since v1.33.11+k3s1:&#xD;&#xA;&#xD;&#xA;* Backports for 2026-05 [(#14035)](https://github.com/k3s-io/k3s/pull/14035)&#xD;&#xA;* Update rancher/local-path-provisioner image version [(#14045)](https://github.com/k3s-io/k3s/pull/14045)&#xD;&#xA;* Update to v1.33.12-k3s1 and Go 1.25.9 [(#14048)](https://github.com/k3s-io/k3s/pull/14048)&#xD;&#xA;* Bump klipper-helm image tag [(#14058)](https://github.com/k3s-io/k3s/pull/14058)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.33.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#v13312) |&#xD;&#xA;| Kine | [v0.15.0](https://github.com/k3s-io/kine/releases/tag/v0.15.0) |&#xD;&#xA;| SQLite | [3.53.0](https://sqlite.org/releaselog/3_53_0.html) |&#xD;&#xA;| Etcd | [v3.6.7-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.6.7-k3s1) |&#xD;&#xA;| Containerd | [v2.2.3-k3s1.33](https://github.com/k3s-io/containerd/releases/tag/v2.2.3-k3s1.33) |&#xD;&#xA;| Runc | [v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) |&#xD;&#xA;| Flannel | [v0.28.4](https://github.com/flannel-io/flannel/releases/tag/v0.28.4) | &#xD;&#xA;| Metrics-server | [v0.8.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1) |&#xD;&#xA;| Traefik | [v3.6.13](https://github.com/traefik/traefik/releases/tag/v3.6.13) |&#xD;&#xA;| CoreDNS | [v1.14.3](https://github.com/coredns/coredns/releases/tag/v1.14.3) | &#xD;&#xA;| Helm-controller | [v0.17.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1) |&#xD;&#xA;| Local-path-provisioner | [v0.0.36](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)</pre>
            </details>
        </details>
        <a href="https://github.com/mprochowski/k3s-cluster-gitops/actions/runs/28219340601">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

