### PR TITLE
cert-manager/cert-manager: bump version to 1.21.1

### DIFF
--- a/.charts/2-services/cert-manager/Chart.yaml
+++ b/.charts/2-services/cert-manager/Chart.yaml
@@ -3,4 +3,4 @@ name: cert-manager
 description: Cert-manager.io
 type: application
 version: 1.0.0
-appVersion: 1.19.4
+appVersion: 1.20.1

--- a/2-services/cert-manager/kustomization.yaml
+++ b/2-services/cert-manager/kustomization.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/cert-manager/cert-manager/releases/download/v1.19.4/cert-manager.yaml
+  - https://github.com/cert-manager/cert-manager/releases/download/v1.20.1/cert-manager.yaml
 
 patches:
   - patch: |-


### PR DESCRIPTION



<Actions>
    <action id="47192c087650391651e2633362e9ab2da7e4eb187c99f7830a5051e5546ce52e">
        <h3>cert-manager/cert-manager</h3>
        <details id="37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f">
            <summary>cert-manager/cert-manager: bump version to 1.21.1</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.appVersion&#34; updated from &#34;1.21.0&#34; to &#34;1.21.1&#34;, in file &#34;.charts/2-services/cert-manager/Chart.yaml&#34;</p>
            <details>
                <summary>v1.21.1</summary>
                <pre>cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.&#xD;&#xA;&#xD;&#xA;v1.21.1 fixes a controller panic for Certificates with `spec.renewal.policy: Disabled`, a regression in 1.21.0 which caused log spam and dropped Secret informer events, Issuers and ClusterIssuers getting stuck at `Ready=False` (`InvalidSolver`) when a referenced ACME DNS-01 solver Secret is created after the Issuer, and the commented Gateway API example in the Helm chart values. It also updates several dependencies to fix reported security vulnerabilities.&#xD;&#xA;&#xD;&#xA;All users should upgrade.&#xD;&#xA;&#xD;&#xA;## Changes by Kind&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- Avoid controller panic if a Certificate sets spec.renewal.policy=Disabled (#9038, @sklirg)&#xD;&#xA;- Fix Issuer/ClusterIssuer stuck at Ready=False/InvalidSolver after a missing ACME DNS-01 solver Secret is created (#9083, @SebTardif)&#xD;&#xA;- Fix log spam and dropped Secret informer events for non-cert-manager Secrets, caused by a generics regression introduced in 1.21.0. (#9037, @wallrj-cyberark)&#xD;&#xA;- Fixed the commented Gateway API config example in the Helm chart values to use `gatewayAPI.enabled` instead of the invalid `gatewayAPI.enable`. (#9012, @mateenali66)&#xD;&#xA;&#xD;&#xA;### Other (Cleanup or Flake)&#xD;&#xA;&#xD;&#xA;- Bump `golang.org/x/text` to v0.40.0 to fix a reported security vulnerability (#9039, @wallrj-cyberark)&#xD;&#xA;- Bump `google.golang.org/grpc` to v1.82.1 to fix a reported security vulnerability (#9063)&#xD;&#xA;- Bump `github.com/google/cel-go` to v0.29.0 to fix a reported security vulnerability (#9072)&#xD;&#xA;- Bump `go.opentelemetry.io/otel` to v1.44.0 to fix a reported security vulnerability (#9073)&#xD;&#xA;- Update distroless base images (#9000, #9025)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.21.0</summary>
                <pre>cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.&#xD;&#xA;&#xD;&#xA;cert-manager 1.21 brings ACME Renewal Information (ARI) support, AWS IAM authentication for the Vault issuer, several security hardening changes, and continued improvements to Gateway API integration and cainjector. There are three breaking changes related to Helm chart RBAC and metrics values — review them carefully before upgrading.&#xD;&#xA;&#xD;&#xA;## Major Themes&#xD;&#xA;&#xD;&#xA;### Default `tokenrequest` RBAC removed from Helm chart&#xD;&#xA;&#xD;&#xA;&gt; ⚠️ Breaking change&#xD;&#xA;&#xD;&#xA;The Helm chart no longer creates a default `Role` and `RoleBinding` granting the cert-manager controller permission to create tokens for its own ServiceAccount (`serviceaccounts/token: create`). No documented workflow requires this RBAC — the Route53 docs section that motivated it was removed in 2024.&#xD;&#xA;&#xD;&#xA;If you use `serviceAccountRef.name` pointing at the controller ServiceAccount, you must now either create your own `Role`/`RoleBinding` granting `serviceaccounts/token: create`, or migrate to a dedicated ServiceAccount (recommended — see the [Vault](https://cert-manager.io/docs/configuration/vault/) or [Route53](https://cert-manager.io/docs/configuration/acme/dns01/route53/) documentation).&#xD;&#xA;&#xD;&#xA;### Restrict Challenge and Order RBAC in `cert-manager-edit` ClusterRole&#xD;&#xA;&#xD;&#xA;&gt; ⚠️ Potentially breaking change&#xD;&#xA;&#xD;&#xA;The `cert-manager-edit` aggregate ClusterRole no longer grants `create` for `challenges.acme.cert-manager.io` or `create`, `patch`, `update` for `orders.acme.cert-manager.io` ([`GHSA-8rvj-mm4h-c258`](https://github.com/cert-manager/cert-manager/security/advisories/GHSA-8rvj-mm4h-c258)). These resources are internal to cert-manager&#39;s ACME workflow. Challenge `patch` and `update` are retained because users may need them to remove stuck finalizers.&#xD;&#xA;&#xD;&#xA;This change was already shipped in v1.20.3 and v1.19.6, so if you are running one of those versions this will not be a breaking change. If you have tooling that creates Challenge or Order resources directly, you will need to grant those permissions explicitly.&#xD;&#xA;&#xD;&#xA;### Metrics port name and path Helm values removed&#xD;&#xA;&#xD;&#xA;&gt; ⚠️ Breaking change&#xD;&#xA;&#xD;&#xA;The Helm values `prometheus.servicemonitor.targetPort`, `prometheus.servicemonitor.path`, and `prometheus.podmonitor.path` have been removed. The controller Service metrics port has been renamed from `tcp-prometheus-servicemonitor` to `http-metrics`. Because the Helm values schema uses `additionalProperties: false`, users who still have any of the removed keys in their values overrides will see a schema validation error on upgrade — remove them before upgrading. (#8952)&#xD;&#xA;&#xD;&#xA;### ACME and Certificate Management&#xD;&#xA;&#xD;&#xA;- **ACME Renewal Information (ARI)**: experimental support for [RFC 9773](https://www.rfc-editor.org/rfc/rfc9773) behind the `ACMEUseARI` feature gate. When enabled, cert-manager queries the ACME server&#39;s `renewalInfo` endpoint for the recommended renewal window, allowing servers like Let&#39;s Encrypt to proactively prompt renewal during mass revocations or CA key rollovers. (#8798)&#xD;&#xA;- **`waitInsteadOfSelfCheck` solver option**: skip cert-manager&#39;s own self-check and instead wait a configured duration before asking the ACME server to validate. An escape hatch for split-horizon DNS and NAT hairpin environments. See [configuration details](https://cert-manager.io/docs/configuration/acme/#skip-the-self-check-with-waitinsteadofselfcheck). (#8858)&#xD;&#xA;- **AWS IAM authentication for Vault**: the Vault issuer now supports IRSA, EKS Pod Identity, and ambient EC2/ECS credentials, removing the need for long-lived AWS Secrets. (#8422)&#xD;&#xA;- **Certificate renewal policies**: a new `renewalPolicies` field on the Certificate API provides more expressive control over renewal scheduling, complementing `renewBefore` and `renewBeforePercentage`. (#8258)&#xD;&#xA;- **Configurable CertificateRequest retry backoff**: the new `--certificate-request-maximum-backoff-duration` flag (default: 32 hours) caps the exponential backoff for failed CertificateRequests, useful for environments with scheduled CA maintenance windows. (#8893)&#xD;&#xA;- **Modern2026 PKCS#12 profile**: a new FIPS 140-3 compatible encoding profile using AES-256 + SHA-256 KDFs instead of legacy 3DES/RC2. (#8841)&#xD;&#xA;- **Webhook certificate renewal after system suspend**: the webhook now detects missed certificate renewals after system suspend (S3/S4) or VM live migration by polling wall-clock time, recovering within one minute of resume. (#8464)&#xD;&#xA;&#xD;&#xA;### Gateway API and cainjector&#xD;&#xA;&#xD;&#xA;- **HTTP01 ListenerSet parentRef fallback**: the `acme.cert-manager.io/http01-parentreffallback: &#34;true&#34;` annotation causes cert-manager to use the parent Gateway for solver HTTPRoutes instead of the ListenerSet, enabling TLS-only ListenerSets to use a shared HTTP listener for ACME challenges. (#8749)&#xD;&#xA;- **`cert-manager.io/ignore-tls-listeners` annotation**: exclude specific Gateway TLS listeners from certificate management. (#8727)&#xD;&#xA;- **Additional listener protocols**: configurable listener protocols beyond the default set. (#8683)&#xD;&#xA;- **`enableGatewayAPI` configuration restructure**: `enableGatewayAPI` and `enableGatewayAPIListenerSet` are deprecated in favor of `gatewayAPI.enabled` / `gatewayAPI.enableListenerSet`. The old fields continue to work. (#8732)&#xD;&#xA;- **`CAInjectorMerging` promoted to GA**: unconditionally enabled; will be removed in a future release. (#8583)&#xD;&#xA;- **cainjector server-side apply unconditional**: the `ServerSideApply` feature gate is deprecated. (#8692)&#xD;&#xA;- **cainjector `--ignore-namespaces` flag**: skip specified namespaces when watching Secrets for injection. (#8614)&#xD;&#xA;&#xD;&#xA;### Deployment and Observability&#xD;&#xA;&#xD;&#xA;- **Venafi OAuth token observability**: a new `AuthFailed` Issuer condition reason distinguishes bad credentials from transient errors. PANW NGTS is now supported as a Venafi backend. (#8808, #8779)&#xD;&#xA;- **`runtimeClassName` support**: configurable for cert-manager components and ACME HTTP01 solver pods. (#8791, #8976)&#xD;&#xA;- **`startupapicheck.ttlSecondsAfterFinished`**: opt-in automatic cleanup of the startupapicheck Job. (#8523)&#xD;&#xA;- **`--acme-http01-solver-extra-labels`**: propagate `global.commonLabels` to dynamically-created ACME HTTP01 solver resources. (#8761)&#xD;&#xA;&#xD;&#xA;### Notable Bug Fixes&#xD;&#xA;&#xD;&#xA;- **Integer overflow in `renewBeforePercentage`**: Certificates with durations longer than approximately 3 years were incorrectly rejected or assigned incorrect renewal times. (#8947)&#xD;&#xA;- **Infinite re-issuance loop**: cert-manager no longer loops when an issuer returns an already-expired certificate. (#8610)&#xD;&#xA;- **ACME transient network errors**: challenges no longer permanently fail on TLS handshake timeouts, DNS resolution failures, or context cancellation during nonce fetches and authorization waits. (#8760)&#xD;&#xA;- **DNS-over-HTTPS response body cap**: response body reads are now bounded at 128 KB to prevent potential OOM. (#8803)&#xD;&#xA;- **Vault path traversal**: the Vault issuer webhook now rejects `..` path segments, preventing `path.Join` from silently resolving relative segments. (#8930)&#xD;&#xA;- **DNS issuer secrets validated before ready**: prevents silent misconfiguration. (#8255)&#xD;&#xA;&#xD;&#xA;## Community&#xD;&#xA;&#xD;&#xA;As always, we&#39;d like to thank all of the community members who helped in this release cycle, including all below who merged a PR and anyone that helped by commenting on issues, testing, or getting involved in cert-manager meetings. We&#39;re lucky to have you involved.&#xD;&#xA;&#xD;&#xA;A special thanks to:&#xD;&#xA;&#xD;&#xA;- @Copilot&#xD;&#xA;- @FelixPhipps&#xD;&#xA;- @Peac36&#xD;&#xA;- @SebTardif&#xD;&#xA;- @apkatsikas&#xD;&#xA;- @bitloi&#xD;&#xA;- @dap0am&#xD;&#xA;- @figaw&#xD;&#xA;- @immanuwell&#xD;&#xA;- @jabbrwcky&#xD;&#xA;- @jnohlgard&#xD;&#xA;- @jsoref&#xD;&#xA;- @ltwongaa&#xD;&#xA;- @lunarwhite&#xD;&#xA;- @mateenali66&#xD;&#xA;- @onurmicoogullari&#xD;&#xA;- @putongyong&#xD;&#xA;- @seanorama&#xD;&#xA;- @texasich&#xD;&#xA;&#xD;&#xA;for their contributions, comments and support!&#xD;&#xA;&#xD;&#xA;Also, thanks to the cert-manager maintainer team for their help in this release:&#xD;&#xA;&#xD;&#xA;- @SgtCoDFish&#xD;&#xA;- @ThatsMrTalbot&#xD;&#xA;- @erikgb&#xD;&#xA;- @hjoshi123&#xD;&#xA;- @inteon&#xD;&#xA;- @maelvls&#xD;&#xA;- @munnerz&#xD;&#xA;- @wallrj&#xD;&#xA;- @wallrj-cyberark&#xD;&#xA;&#xD;&#xA;And finally, thanks to the cert-manager steering committee for their feedback in this release cycle:&#xD;&#xA;&#xD;&#xA;- @FlorianLiebhart&#xD;&#xA;- @TrilokGeer&#xD;&#xA;- @ianarsenault&#xD;&#xA;- @ssyno&#xD;&#xA;&#xD;&#xA;## Changes since v1.20.0&#xD;&#xA;&#xD;&#xA;### Feature&#xD;&#xA;&#xD;&#xA;- Add Venafi OAuth token request observability and a new `AuthFailed` Issuer condition reason to distinguish bad credentials from transient infrastructure errors. (#8808, @FelixPhipps)&#xD;&#xA;- Add `certificateRequestMaximumBackoffDuration` controller configuration option to cap retry backoff time for failed CertificateRequests. Configurable via config file, `--certificate-request-maximum-backoff-duration` CLI flag, or Helm value `config.certificateRequestMaximumBackoffDuration`. Defaults to 32 hours for backward compatibility. (#8893, @lunarwhite)&#xD;&#xA;- Add an optional `waitInsteadOfSelfCheck` field to ACME HTTP01 and DNS01 solvers so cert-manager can skip its own self-check and ask the ACME server to validate after a configured wait. (#8858, @wallrj)&#xD;&#xA;- Add configurable `runtimeClassName` support for cert-manager components and ACME HTTP01 solver pods. (#8791, @jsoref)&#xD;&#xA;- Add direct configurable `runtimeClassName` support for ACME HTTP01 solver pods via the `acmesolver.runtimeClassName` Helm value. (#8976, @erikgb)&#xD;&#xA;- Add new controller flag `--acme-http01-solver-extra-labels`, allowing Helm&#39;s `global.commonLabels` to propagate to all dynamically-created ACME HTTP01 solver resources (Pods, Services, Ingresses, or Gateway API HTTPRoutes). (#8761, @lunarwhite)&#xD;&#xA;- Add opt-in `startupapicheck.ttlSecondsAfterFinished` Helm value to enable automatic cleanup of the startupapicheck Job via the Kubernetes TTL-after-finished controller. (#8523, @dap0am)&#xD;&#xA;- Added ARI support through the ACMEUseARI feature gate. (#8798, @hjoshi123)&#xD;&#xA;- Added AWS IAM authentication support for Vault issuer, including IRSA (IAM Roles for Service Accounts) and ambient credentials (EC2/ECS). (#8422, @bitloi)&#xD;&#xA;- Added `cert-manager.io/ignore-tls-listeners` annotation for ignoring gwapi listeners. (#8727, @hjoshi123)&#xD;&#xA;- Added option to specify additional listener protocols the GatewayAPI integration will consider when creating certificates. (#8683, @ThatsMrTalbot)&#xD;&#xA;- Adds support for the Modern2026 go-pkcs12 profile and FIPS 140-3 (#8841, @seanorama)&#xD;&#xA;- Cainjector: A new flag `--ignore-namespaces` was added to the cainjector binary. It can be used to filter out namespaces from being watched for secrets to use for injectables. (#8614, @figaw)&#xD;&#xA;- Disabled client side rate-limiting if AP&amp;F is enabled. (#8757, @hjoshi123)&#xD;&#xA;- Extend the Venafi/CyberArk integration to also support PANW NGTS. (#8779, @FelixPhipps)&#xD;&#xA;- Adding certificate renewal policies (#8258, @hjoshi123)&#xD;&#xA;- Make cainjector use SSA unconditionally and deprecate the ServerSideApply feature gate (#8692, @erikgb)&#xD;&#xA;- Processed annotations `cert-manager.io/alt-names`, `cert-manager.io/ip-sans` to Certificates generated from ingress like objects in cert-shim controllers. (#8927, @jabbrwcky)&#xD;&#xA;- Promote the CAInjectorMerging feature gate to GA (#8583, @Copilot)&#xD;&#xA;- When using ACME HTTP-01 with a ListenerSet, setting the annotation `acme.cert-manager.io/http01-parentreffallback: &#34;true&#34;` causes cert-manager to use the parent Gateway as the solver HTTPRoute parentRef instead of the ListenerSet. This enables TLS-only ListenerSets to rely on a shared Gateway HTTP listener for ACME challenges. (#8749, @apkatsikas)&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- **BREAKING**: The Helm chart no longer ships a default `Role` and `RoleBinding` granting the cert-manager controller ServiceAccount permission to create tokens for itself (`serviceaccounts/token: create`). This RBAC was added in v1.16 (#7213) but no documented workflow requires it, and the motivating Route53 docs section was removed in Oct 2024. If you rely on `serviceAccountRef.name` pointing at the controller ServiceAccount (an undocumented pattern), you must now create your own `Role` and `RoleBinding` granting `serviceaccounts/token: create` on that ServiceAccount, or migrate to one of the documented patterns (IRSA ambient, or a dedicated ServiceAccount with its own RBAC). (#8931, @wallrj-cyberark)&#xD;&#xA;- ACME challenges no longer terminally fail on transient network errors (TLS handshake timeouts, DNS failures, context cancellation) during nonce fetches and authorization waits. The challenge controller returns the error and lets the workqueue retry with backoff. (#8760, @texasich)&#xD;&#xA;- Add dns issuer secrets validation before marking it as ready (#8255, @Peac36)&#xD;&#xA;- Add missing issuer finalizer RBAC to the order controller to support owner references (#8654, @erikgb)&#xD;&#xA;- ClusterIssuer metrics collector now correctly respects the enabled-controllers configuration, avoiding a redundant startup when only operating within a namespace. (#8822, @lunarwhite)&#xD;&#xA;- Fix Venafi TPP issuer setup and signing regression on master: restore authentication of the vcert connector in the client constructor, which was removed in #8808. (#8843, @wallrj-cyberark)&#xD;&#xA;- Fix a performance issue in the certificateRequestApproval webhook where CertificateRequests referencing a GroupKind whose CRD is not yet installed would trigger repeated API server discovery queries on every admission request. Negative results are now cached for 30 seconds. (#8651, @mateenali66)&#xD;&#xA;- Fix webhook serving certificate not being renewed after system suspend. (#8464, @Peac36)&#xD;&#xA;- Fixed a rare panic in the trigger controller when a Certificate is deleted from the informer cache while a reconcile is in progress (e.g. during namespace teardown). (#8962, @hjoshi123)&#xD;&#xA;- Fixed an integer overflow in `renewBeforePercentage` calculations that caused Certificates with durations longer than approximately 3 years to be incorrectly rejected by validation or assigned incorrect renewal times. (#8947, @ThatsMrTalbot)&#xD;&#xA;- Fixed duplicate `parentRef` bug when both issuer config and annotations are present. (#8619, @hjoshi123)&#xD;&#xA;- Fixed infinite re-issuance loop when issuer returns an already expired certificate (#8610, @onurmicoogullari)&#xD;&#xA;- Fixed local `e2e-setup-samplewebhook` installation to use the samplewebhook image repository and tag from the saved image tarball manifest. (#8821, @wallrj)&#xD;&#xA;- Fixed potential OOM in DNS-over-HTTPS client by bounding response body read with io.LimitReader (128 KB cap). (#8803, @SebTardif)&#xD;&#xA;- Fixed validation of timezone-prefixed renewal window cron specs without a schedule. (#8813, @immanuwell)&#xD;&#xA;- Helm chart bugfix: rename image helper to avoid umbrella chart conflicts (#8753, @FelixPhipps)&#xD;&#xA;- Helm: Fix invalid YAML generated when both `webhook.config` and `webhook.volumes` are defined. (#8664, @jnohlgard)&#xD;&#xA;- Remove ACME Challenge `create` and Order `create`/`patch`/`update` from the cert-manager-edit aggregate ClusterRole to prevent direct manipulation of these internal resources (GHSA-8rvj-mm4h-c258). (#8958, @wallrj-cyberark)&#xD;&#xA;- Remove issuer owner reference from challenges blocking challenge garbage collection (#8743, @erikgb)&#xD;&#xA;- Update logic to identify and preserve the secret matching nextPrivateKeySecretName (#8577, @putongyong)&#xD;&#xA;- Vault Issuer webhook validation now rejects `..` path segments in `spec.vault.path` and auth mount path fields, preventing `path.Join` from silently resolving relative segments before constructing the Vault API request. (#8930, @wallrj-cyberark)&#xD;&#xA;&#xD;&#xA;### Other (Cleanup or Flake)&#xD;&#xA;&#xD;&#xA;- API cleanup: removed deprecated ObjectReference (#8625, @inteon)&#xD;&#xA;- Remove Helm values `prometheus.servicemonitor.targetPort`, `prometheus.servicemonitor.path`, and `prometheus.podmonitor.path`. The metrics path is always `/metrics` and the target port is always `http-metrics`. Rename the controller service metrics port from `tcp-prometheus-servicemonitor` to `http-metrics` for consistency with other workloads. Users must remove these keys from their value overrides before upgrading. (#8952, @erikgb)&#xD;&#xA;- The `enableGatewayAPI` and `enableGatewayAPIListenerSet` fields on `ControllerConfiguration` are deprecated and moved into the `gatewayAPI` sub-struct as `gatewayAPI.enabled` and `gatewayAPI.enableListenerSet`. The old fields continue to work. (#8732, @ThatsMrTalbot)&#xD;&#xA;- Update base images to Debian 13 (#8849, @ltwongaa)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v1.20.3</summary>
                <pre>cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.&#xD;&#xA;&#xD;&#xA;v1.20.3 removes the issuer owner reference from challenges which was blocking challenge garbage collection, removes unnecessary write verbs from the `cert-manager-edit` aggregate ClusterRole, and updates Go to fix reported CVEs.&#xD;&#xA;&#xD;&#xA;## Changes by Kind&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- Remove Challenge `create` and Order `create`, `patch`, `update` verbs from the `cert-manager-edit` aggregate ClusterRole. (#8940, @wallrj-cyberark)&#xD;&#xA;- Remove issuer owner reference from challenges blocking challenge garbage collection (#8759, @cert-manager-bot)&#xD;&#xA;&#xD;&#xA;### Other (Cleanup or Flake)&#xD;&#xA;&#xD;&#xA;- Bump go to 1.26.3, other deps to fix several govulncheck issues (#8789, @SgtCoDFish)&#xD;&#xA;- Update Go to `v1.26.4` to fix CVE-2026-27145, CVE-2026-42504, and CVE-2026-42507 (#8926, @wallrj-cyberark)</pre>
            </details>
            <details>
                <summary>v1.20.2</summary>
                <pre>v1.20.2 fixes invalid YAML generated in the Helm chart when both `webhook.config`&#xD;&#xA;and `webhook.volumes` are defined, and bumps Go to 1.26.2 along with dependencies&#xD;&#xA;to address reported vulnerabilities.&#xD;&#xA;&#xD;&#xA;## Changes by Kind&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- Helm: Fix invalid YAML generated when both `webhook.config` and `webhook.volumes` are defined. (#8665, @cert-manager-bot)&#xD;&#xA;&#xD;&#xA;### Other (Cleanup or Flake)&#xD;&#xA;&#xD;&#xA;- Bump go dependencies with reported vulnerabilities (#8704, @erikgb)&#xD;&#xA;- Bump go to 1.26.2 (#8703, @erikgb)</pre>
            </details>
            <details>
                <summary>v1.20.1</summary>
                <pre>v1.20.1 fixes an issue for OpenShift users that has to do with the finalizer RBAC, bumps gRPC to address a reported non-affecting vulnerability, and fixes a duplicate `parentRef` bug when both issuer config and annotations are present (Gateway API).&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- Fixed duplicate `parentRef` bug when both issuer config and annotations are present. (#8658, @hjoshi123)&#xD;&#xA;- Add missing issuer finalizer RBAC to the order controller to support owner references. This was preventing OpenShift users from being able to upgrade to v1.20.0. (#8655, @erikgb)&#xD;&#xA;- Bump google.golang.org/grpc to fix vulnerability reported by scanners. This isn&#39;t a vulnerability that affects cert-manager, but we are bumping it because it is reported by scanners. (#8657, @erikgb)&#xD;&#xA;</pre>
            </details>
        </details>
        <a href="https://github.com/mprochowski/k3s-cluster-gitops/actions/runs/23953176449">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

